### PR TITLE
Add new Serialize Method, omit TextWriter, return string

### DIFF
--- a/Jil/JSON.cs
+++ b/Jil/JSON.cs
@@ -85,6 +85,21 @@ namespace Jil
             }
         }
 
+        /// <summary>
+        /// Serializes the given data, returning the output as a string.
+        /// 
+        /// Pass an Options object to configure the particulars (such as whitespace, and DateTime formats) of
+        /// the produced JSON.  If omitted, Options.Default is used.
+        /// </summary>
+        public static string Serialize<T>(T data, Options options = null)
+        {
+            using (var str = new StringWriter())
+            {
+                Serialize(data, str, options);
+                return str.ToString();
+            }
+        }
+
         static void NewtonsoftStyle<T>(T data, TextWriter output, Options options)
         {
             if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.IsJSONP)

--- a/JilTests/SerializeTests.cs
+++ b/JilTests/SerializeTests.cs
@@ -30,6 +30,17 @@ namespace JilTests
             }
         }
 
+        [TestMethod]
+        public void SimpleObject_ToString()
+        {
+            using (var str = new StringWriter())
+            {
+                var res = JSON.Serialize(new _SimpleObject { Foo = 123 });
+
+                Assert.AreEqual("{\"Foo\":123}", res);
+            }
+        }
+
         public class _Cyclical
         {
             public int Foo;


### PR DESCRIPTION
Add an overload to the `Serialize<T>` function that omits the `TextWriter output` parameter, and instead instantiates a new `StringWriter`, uses this as the output in a call to `Serialize` and returns the string directly. Useful because in many normal use cases, users might not want to have to deal with a `TextWriter` and are only interested in the resulting serialized string.
