### PR TITLE
Correct nested dictionary serialization

### DIFF
--- a/Jil/Serialize/InlineSerializer.cs
+++ b/Jil/Serialize/InlineSerializer.cs
@@ -2586,7 +2586,7 @@ namespace Jil.Serialize
 
                 if (elementType.IsDictionaryType())
                 {
-                    WriteList(elementType, loc);
+                    WriteDictionary(elementType, loc);
                     return;
                 }
 

--- a/JilTests/SerializeTests.cs
+++ b/JilTests/SerializeTests.cs
@@ -6031,5 +6031,25 @@ namespace JilTests
                 Assert.AreEqual(i.ToString(), str);
             }
         }
+
+        private class simplePoco
+        {
+            public string Name { get; set; }
+            public int Id { get; set; }
+        }
+
+        [TestMethod]
+        public void SerializeNestedDictionary()
+        {
+            var items = new Dictionary<string, Dictionary<string, simplePoco>>();
+            items.Add("a", new Dictionary<string, simplePoco>
+            {
+                {"a", new simplePoco {Id = 1, Name = "a"}}, 
+                {"b", new simplePoco {Id = 2, Name = "b"}}
+            });
+            var json = JSON.Serialize(items);
+            string expectedJson = "{\"a\":{\"a\":{\"Id\":1,\"Name\":\"a\"},\"b\":{\"Id\":2,\"Name\":\"b\"}}}";
+            Assert.AreEqual(expectedJson, json);
+        }
     }
 }


### PR DESCRIPTION
I encountered an error trying to serialize nested dictionaries. See attached unit test. I think I was able to fix the issue - Dictionary type element was erroneously trying to use `WriteList` instead of `WriteDictionary`.
