### PR TITLE
Failing test for deserialize object[]

### DIFF
--- a/JilTests/DeserializeTests.cs
+++ b/JilTests/DeserializeTests.cs
@@ -3364,5 +3364,23 @@ namespace JilTests
                 Assert.AreEqual(8, first.I);
             }
         }
+
+        private class testClass
+        {
+            public object[][] Items { get; set; }
+        }
+
+        [TestMethod]
+        public void Deserialize_DoubleObjectArrayProperty()
+        {
+            string json = "{\"Items\": [[\"email1@stackoverflow.com\", 7], [\"email2@stackoverflow.com\", 4]]}";
+            testClass items = JSON.Deserialize<testClass>(json);
+            Assert.IsNotNull(items);
+            Assert.IsNotNull(items.Items);
+            Assert.AreEqual(2, items.Items.Length);
+            Assert.AreEqual("email1@stackoverflow.com", items.Items[0][0].ToString());
+            Assert.IsTrue(items.Items[0][1] is int);
+            Assert.AreEqual(7, Convert.ToInt32(items.Items[0][1]));
+        }
     }
 }


### PR DESCRIPTION
Attached is a failing test for a deserialization issue that I ran into when trying to integrate Jil with my project. Issue is specifically when deserializing a double object array.

Stack Trace of exception thrown:

> Test method JilTests.DeserializeTests.Deserialize_DoubleObjectArrayProperty threw exception: 
> System.TypeInitializationException: The type initializer for 'Jil.Deserialize.NewtonsoftStyleTypeCache'1' threw an exception. ---> System.InvalidOperationException: Sequence contains no elements
> at System.Linq.Enumerable.Max(IEnumerable'1 source)
> at System.Linq.Enumerable.Max(IEnumerable'1 source, Func'2 selector)
> at Jil.Deserialize.InlineDeserializer'1.ReadObjectHashing(Type objType) in InlineDeserializer.cs: line 878
> at Jil.Deserialize.InlineDeserializer'1.ReadObject(Type objType) in InlineDeserializer.cs: line 821
> at Jil.Deserialize.InlineDeserializer'1.Build(Type forType, Boolean allowRecursion) in InlineDeserializer.cs: line 1365
> at Jil.Deserialize.InlineDeserializer'1.ReadList(Type listType) in InlineDeserializer.cs: line 606
> at Jil.Deserialize.InlineDeserializer'1.Build(Type forType, Boolean allowRecursion) in InlineDeserializer.cs: line 1344
> at Jil.Deserialize.InlineDeserializer'1.ReadList(Type listType) in InlineDeserializer.cs: line 606
> at Jil.Deserialize.InlineDeserializer'1.Build(Type forType, Boolean allowRecursion) in InlineDeserializer.cs: line 1344
> at Jil.Deserialize.InlineDeserializer'1.ReadObjectHashing(Type objType) in InlineDeserializer.cs: line 961
> at Jil.Deserialize.InlineDeserializer'1.ReadObject(Type objType) in InlineDeserializer.cs: line 821
> at Jil.Deserialize.InlineDeserializer'1.Build(Type forType, Boolean allowRecursion) in InlineDeserializer.cs: line 1365
> at Jil.Deserialize.InlineDeserializer'1.BuildWithNewDelegate() in InlineDeserializer.cs: line 1387
> at Jil.Deserialize.InlineDeserializerHelper.Build(Type typeCacheType, DateTimeFormat dateFormat, Boolean allowHashing) in InlineDeserializer.cs: line 1407
> at Jil.Deserialize.NewtonsoftStyleTypeCache'1..cctor() in TypeCaches.cs: line 16
> --- End of inner exception stack trace ---
> at Jil.JSON.Deserialize(TextReader reader, Options options) in JSON.cs: line 536
> at Jil.JSON.Deserialize(String text, Options options) in JSON.cs: line 573
> at JilTests.DeserializeTests.Deserialize_DoubleObjectArrayProperty() in DeserializeTests.cs: line 3377
