### PR TITLE
Using InvariantCulture instead of Threads culture to Deserialize data

### DIFF
--- a/Jil/Deserialize/Methods.ReadNumbers.cs
+++ b/Jil/Deserialize/Methods.ReadNumbers.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -910,7 +911,7 @@ namespace Jil.Deserialize
                 // exponent?
                 if (c == 'e' || c == 'E')
                 {
-                    var leading = double.Parse(commonSb.ToString()) * (negative ? -1.0 : 1.0);
+                    var leading = double.Parse(commonSb.ToString(), CultureInfo.InvariantCulture) * (negative ? -1.0 : 1.0);
                     commonSb.Clear();   // cleanup for the next use
                     reader.Read();
 
@@ -931,7 +932,7 @@ namespace Jil.Deserialize
                 throw new DeserializationException(msg, reader);
             }
 
-            var ret = double.Parse(commonSb.ToString());
+            var ret = double.Parse(commonSb.ToString(), CultureInfo.InvariantCulture);
             commonSb.Clear();   // cleanup for the next use
 
             return ret * (negative ? -1.0 : 1.0);
@@ -992,7 +993,7 @@ namespace Jil.Deserialize
                 if (c == 'e' || c == 'E')
                 {
                     // we're doing the math in doubles intentionally here, for precisions sake
-                    var leading = double.Parse(commonSb.ToString()) * (negative ? -1.0 : 1.0);
+                    var leading = double.Parse(commonSb.ToString(), CultureInfo.InvariantCulture) * (negative ? -1.0 : 1.0);
                     commonSb.Clear();   // cleanup for the next use
                     reader.Read();
 
@@ -1013,10 +1014,10 @@ namespace Jil.Deserialize
                 throw new DeserializationException(msg, reader);
             }
 
-            var ret = float.Parse(commonSb.ToString());
+            var ret = float.Parse(commonSb.ToString(), CultureInfo.InvariantCulture);
             commonSb.Clear();   // cleanup for the next use
 
-            return ret * (negative ? -1f : 1f );
+            return ret * (negative ? -1f : 1f);
         }
 
         public static readonly MethodInfo ReadDecimal = typeof(Methods).GetMethod("_ReadDecimal", BindingFlags.Static | BindingFlags.NonPublic);
@@ -1073,7 +1074,7 @@ namespace Jil.Deserialize
                 // exponent?
                 if (c == 'e' || c == 'E')
                 {
-                    var leading = decimal.Parse(commonSb.ToString()) * (negative ? -1m : 1m);
+                    var leading = decimal.Parse(commonSb.ToString(), CultureInfo.InvariantCulture) * (negative ? -1m : 1m);
                     commonSb.Clear();   // cleanup for the next use
                     reader.Read();
 
@@ -1094,7 +1095,7 @@ namespace Jil.Deserialize
                 throw new DeserializationException(msg, reader);
             }
 
-            var ret = decimal.Parse(commonSb.ToString());
+            var ret = decimal.Parse(commonSb.ToString(), CultureInfo.InvariantCulture);
             commonSb.Clear();   // cleanup for the next use
 
             return ret * (negative ? -1m : 1m);

--- a/JilTests/DeserializeTests.cs
+++ b/JilTests/DeserializeTests.cs
@@ -2,6 +2,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -1919,12 +1920,12 @@ namespace JilTests
         {
             for (var i = -11.1m; i <= 22.2m; i += 0.03m)
             {
-                var asStr = i.ToString();
+                var asStr = i.ToString(CultureInfo.InvariantCulture);
                 using (var str = new StringReader(asStr))
                 {
                     var res = JSON.Deserialize<decimal>(str);
 
-                    Assert.AreEqual(asStr, res.ToString());
+                    Assert.AreEqual(asStr, res.ToString(CultureInfo.InvariantCulture));
                     Assert.AreEqual(-1, str.Peek());
                 }
             }
@@ -1952,12 +1953,12 @@ namespace JilTests
                 decimal d = rand.Next() * (rand.Next() % 2 == 0 ? -1 : 1);
                 d *= (decimal)rand.NextDouble();
 
-                var asStr = d.ToString();
+                var asStr = d.ToString(CultureInfo.InvariantCulture);
                 using (var str = new StringReader(asStr))
                 {
                     var res = JSON.Deserialize<decimal>(str);
 
-                    Assert.AreEqual(asStr, res.ToString());
+                    Assert.AreEqual(asStr, res.ToString(CultureInfo.InvariantCulture));
                     Assert.AreEqual(-1, str.Peek());
                 }
             }
@@ -1968,12 +1969,12 @@ namespace JilTests
         {
             for (var i = -11.1; i <= 22.2; i += 0.03)
             {
-                var asStr = i.ToString();
+                var asStr = i.ToString(CultureInfo.InvariantCulture);
                 using (var str = new StringReader(asStr))
                 {
                     var res = JSON.Deserialize<double>(str);
 
-                    Assert.AreEqual(asStr, res.ToString());
+                    Assert.AreEqual(asStr, res.ToString(CultureInfo.InvariantCulture));
                     Assert.AreEqual(-1, str.Peek());
                 }
             }
@@ -2001,12 +2002,12 @@ namespace JilTests
                 double d = rand.Next() * (rand.Next() % 2 == 0 ? -1 : 1);
                 d *= rand.NextDouble();
 
-                var asStr = d.ToString();
+                var asStr = d.ToString(CultureInfo.InvariantCulture);
                 using (var str = new StringReader(asStr))
                 {
                     var res = JSON.Deserialize<double>(str);
 
-                    Assert.AreEqual(asStr, res.ToString());
+                    Assert.AreEqual(asStr, res.ToString(CultureInfo.InvariantCulture));
                     Assert.AreEqual(-1, str.Peek());
                 }
             }
@@ -2017,12 +2018,12 @@ namespace JilTests
         {
             for (var i = -11.1f; i <= 22.2f; i += 0.03f)
             {
-                var asStr = i.ToString();
+                var asStr = i.ToString(CultureInfo.InvariantCulture);
                 using (var str = new StringReader(asStr))
                 {
                     var res = JSON.Deserialize<float>(str);
 
-                    Assert.AreEqual(asStr, res.ToString());
+                    Assert.AreEqual(asStr, res.ToString(CultureInfo.InvariantCulture));
                     Assert.AreEqual(-1, str.Peek());
                 }
             }
@@ -2050,12 +2051,12 @@ namespace JilTests
                 float f = rand.Next() * (rand.Next() % 2 == 0 ? -1 : 1);
                 f *= (float)rand.NextDouble();
 
-                var asStr = f.ToString();
+                var asStr = f.ToString(CultureInfo.InvariantCulture);
                 using (var str = new StringReader(asStr))
                 {
                     var res = JSON.Deserialize<float>(str);
 
-                    Assert.AreEqual(asStr, res.ToString());
+                    Assert.AreEqual(asStr, res.ToString(CultureInfo.InvariantCulture));
                     Assert.AreEqual(-1, str.Peek());
                 }
             }


### PR DESCRIPTION
On computers with culture where decimal separator is not dot but comma(de-DE for example). Jil serialized with comma. This commit is only fixing Deserializing and not Serializing.

Problem with serializing is that is using StringWriter.Write which has property FormatProvider but this can only be set in constructor which is constructed outside Jil code(user creates it) and sends to Jil. I will leave this one to you Kevin since seems like breaking change. To test this you can do this I think:

At start of test like Primitive add this line:

``` csharp
[TestMethod]
public void Primitive()
{
    System.Threading.Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo("de-DE");
```

Since we are all about speed and stuff I also checked what this means for performance... Seems like even some boost is achieved :)

``` csharp
static void Main(string[] args)
{
    int LOOPS = 10000000;
    for (int j = 0; j < 10; j++)
    {
        {
            Stopwatch SW = Stopwatch.StartNew();
            for (double i = 0; i < LOOPS; i++)
            {
                double.Parse(i.ToString(CultureInfo.InvariantCulture), CultureInfo.InvariantCulture);
            }
            SW.Stop();
            Console.WriteLine("Invariant:" + SW.ElapsedMilliseconds);
        }
        {
            Stopwatch SW = Stopwatch.StartNew();
            for (double i = 0; i < LOOPS; i++)
            {
                double.Parse(i.ToString());
            }
            SW.Stop();
            Console.WriteLine("Thread   :" + SW.ElapsedMilliseconds);
        }
    }
    Console.ReadLine();
}
```

```
Invariant:3542
Thread   :3731
Invariant:3536
Thread   :3718
Invariant:3540
Thread   :3726
Invariant:3536
Thread   :3710
Invariant:3540
Thread   :3723
```
