### PR TITLE
Special-case T==object, which can occur when using anon-types between as...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin/
 obj/
 *.suo
+*.sln.ide/

--- a/Jil.sln
+++ b/Jil.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 2013
+VisualStudioVersion = 12.0.30501.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jil", "Jil\Jil.csproj", "{73D243E7-DD9B-4546-9B71-4EE8BF5ED6C3}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JilTests", "JilTests\JilTests.csproj", "{9D12CD30-3BCE-4CC4-BC8A-94C951802804}"

--- a/Jil/JSON.cs
+++ b/Jil/JSON.cs
@@ -97,6 +97,11 @@ namespace Jil
         /// </summary>
         public static void Serialize<T>(T data, TextWriter output, Options options = null)
         {
+            if (typeof(T) == typeof(object))
+            {
+                SerializeDynamic(data, output, options);
+                return;
+            }
             options = options ?? Options.Default;
 
             switch (options.UseDateTimeFormat)
@@ -129,6 +134,9 @@ namespace Jil
         /// </summary>
         public static string Serialize<T>(T data, Options options = null)
         {
+            if (typeof(T) == typeof(object))
+                return SerializeDynamic(data, options);
+
             options = options ?? Options.Default;
 
             using (var str = new StringWriter(System.Globalization.CultureInfo.InvariantCulture))
@@ -526,6 +534,8 @@ namespace Jil
         /// </summary>
         public static T Deserialize<T>(TextReader reader, Options options = null)
         {
+            if (typeof(T) == typeof(object))
+                return DeserializeDynamic(reader, options);
             try
             {
 
@@ -578,6 +588,8 @@ namespace Jil
         /// </summary>
         public static T Deserialize<T>(string text, Options options = null)
         {
+            if (typeof(T) == typeof(object))
+                return DeserializeDynamic(text, options);
             using (var reader = new StringReader(text))
             {
                 return Deserialize<T>(reader, options);

--- a/JilTests/BadlySpecifiedTypeTests.cs
+++ b/JilTests/BadlySpecifiedTypeTests.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+
+namespace JilTests
+{
+    [TestClass]
+    public class BadlySpecifiedTypeTests
+    {
+        [TestMethod]
+        public void SerializeString()
+        {
+            object obj = new { Foo = 123, Bar = "abc" };
+            string s = Jil.JSON.Serialize(obj), t = Jil.JSON.SerializeDynamic(obj);
+            Assert.AreEqual(t, s);
+        }
+
+        [TestMethod]
+        public void SerializeWriter()
+        {
+            object obj = new { Foo = 123, Bar = "abc" };
+            StringWriter s = new StringWriter(), t = new StringWriter();
+            Jil.JSON.Serialize(obj, s);
+            Jil.JSON.SerializeDynamic(obj, t);
+            Assert.AreEqual(t.ToString(), s.ToString());
+        }
+
+        [TestMethod]
+        public void DeserializeString()
+        {
+            string json = Jil.JSON.SerializeDynamic(new { Foo = 123, Bar = "abc" });
+            dynamic s = Jil.JSON.Deserialize<object>(json),
+                t = Jil.JSON.DeserializeDynamic(json);
+            Assert.AreEqual((int)t.Foo, (int)s.Foo);
+            Assert.AreEqual((string)t.Bar, (string)s.Bar);
+        }
+
+        [TestMethod]
+        public void DeserializeReader()
+        {
+            string json = Jil.JSON.SerializeDynamic(new { Foo = 123, Bar = "abc" });
+            dynamic s = Jil.JSON.Deserialize<object>(new StringReader(json)),
+                t = Jil.JSON.DeserializeDynamic(new StringReader(json));
+            Assert.AreEqual((int)t.Foo, (int)s.Foo);
+            Assert.AreEqual((string)t.Bar, (string)s.Bar);
+        }
+    }
+}

--- a/JilTests/JilTests.csproj
+++ b/JilTests/JilTests.csproj
@@ -100,6 +100,7 @@
     <Compile Include="DeserializeDynamicTests.cs" />
     <Compile Include="DeserializeTests.cs" />
     <Compile Include="ExhaustiveTests.cs" />
+    <Compile Include="BadlySpecifiedTypeTests.cs" />
     <Compile Include="SerializeTests.cs" />
     <Compile Include="SpeedProofTests.cs" />
     <Compile Include="UtilsTests.cs" />


### PR DESCRIPTION
Special-case T==object, which can occur when using anon-types between assemblies, or which just generally means the caller is probably doing something wrong
