### PR TITLE
TypedReflection class

### DIFF
--- a/Jil/Common/TypedReflection.cs
+++ b/Jil/Common/TypedReflection.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Jil.Common
 {
-    static class Typesafe
+    static class TypedReflection
     {
         private static MethodInfo GetMethod(LambdaExpression example)
         {

--- a/Jil/Deserialize/InlineDeserializer.cs
+++ b/Jil/Deserialize/InlineDeserializer.cs
@@ -101,7 +101,7 @@ namespace Jil.Deserialize
             Emit.LoadLocalAddress(StringBuilderName);
         }
 
-        static MethodInfo TextReader_Read = Typesafe.Method((TextReader tr) => tr.Read());
+        static MethodInfo TextReader_Read = TypedReflection.Method((TextReader tr) => tr.Read());
         void RawReadChar(Action endOfStream)
         {
             var haveChar = Emit.DefineLabel();
@@ -351,7 +351,7 @@ namespace Jil.Deserialize
             ExpectQuote();                  // Guid
         }
 
-        static readonly ConstructorInfo DateTimeOffsetConst = Typesafe.Constructor(() => new DateTimeOffset(default(DateTime)));
+        static readonly ConstructorInfo DateTimeOffsetConst = TypedReflection.Constructor(() => new DateTimeOffset(default(DateTime)));
         void ReadDateTimeOffset()
         {
             ReadDate();                             // DateTime
@@ -502,7 +502,7 @@ namespace Jil.Deserialize
             Emit.MarkLabel(success);        // --empty--
         }
 
-        static readonly MethodInfo TextReader_Peek = Typesafe.Method((TextReader tr) => tr.Peek());
+        static readonly MethodInfo TextReader_Peek = TypedReflection.Method((TextReader tr) => tr.Peek());
         void RawPeekChar()
         {
             Emit.LoadArgument(0);                   // TextReader
@@ -1980,8 +1980,8 @@ namespace Jil.Deserialize
             }
         }
 
-        static ConstructorInfo OptionsCons = Typesafe.Constructor(() => new Options(default(bool), default(bool), default(bool), default(DateTimeFormat), default(bool), default(bool)));
-        static ConstructorInfo ObjectBuilderCons = Typesafe.Constructor(() => new Jil.DeserializeDynamic.ObjectBuilder(default(Options)));
+        static ConstructorInfo OptionsCons = TypedReflection.Constructor(() => new Options(default(bool), default(bool), default(bool), default(DateTimeFormat), default(bool), default(bool)));
+        static ConstructorInfo ObjectBuilderCons = TypedReflection.Constructor(() => new Jil.DeserializeDynamic.ObjectBuilder(default(Options)));
         void ReadDynamic()
         {
             using (var dyn = Emit.DeclareLocal<Jil.DeserializeDynamic.ObjectBuilder>())

--- a/Jil/Deserialize/Methods.ISO8601.cs
+++ b/Jil/Deserialize/Methods.ISO8601.cs
@@ -12,7 +12,7 @@ namespace Jil.Deserialize
 {
     partial class Methods
     {
-        public static readonly MethodInfo ReadISO8601Date = Typesafe.Method(() => Methods._ReadISO8601Date(default(TextReader), default(char[])));
+        public static readonly MethodInfo ReadISO8601Date = TypedReflection.Method(() => Methods._ReadISO8601Date(default(TextReader), default(char[])));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static DateTime _ReadISO8601Date(TextReader reader, char[] buffer)
         {

--- a/Jil/Deserialize/Methods.ReadNumbers.cs
+++ b/Jil/Deserialize/Methods.ReadNumbers.cs
@@ -24,7 +24,7 @@ namespace Jil.Deserialize
     //      * *except* for long, where we accumulate into a ulong and do the special checked; because there's no larger type
     static partial class Methods
     {
-        public static readonly MethodInfo DiscardNewtonsoftTimeZoneOffset = Typesafe.Method(() => _DiscardNewtonsoftTimeZoneOffset(default(TextReader)));
+        public static readonly MethodInfo DiscardNewtonsoftTimeZoneOffset = TypedReflection.Method(() => _DiscardNewtonsoftTimeZoneOffset(default(TextReader)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static void _DiscardNewtonsoftTimeZoneOffset(TextReader reader)
         {
@@ -75,7 +75,7 @@ namespace Jil.Deserialize
             if (temp > 59) throw new DeserializationException("Expected minute portion of timezone offset between 0 and 59", reader);
         }
 
-        public static readonly MethodInfo ReadUInt8 = Typesafe.Method(() => _ReadUInt8(default(TextReader)));
+        public static readonly MethodInfo ReadUInt8 = TypedReflection.Method(() => _ReadUInt8(default(TextReader)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static byte _ReadUInt8(TextReader reader)
         {
@@ -115,7 +115,7 @@ namespace Jil.Deserialize
             }
         }
 
-        public static readonly MethodInfo ReadInt8 = Typesafe.Method(() => _ReadInt8(default(TextReader)));
+        public static readonly MethodInfo ReadInt8 = TypedReflection.Method(() => _ReadInt8(default(TextReader)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static sbyte _ReadInt8(TextReader reader)
         {
@@ -165,7 +165,7 @@ namespace Jil.Deserialize
             }
         }
 
-        public static readonly MethodInfo ReadInt16 = Typesafe.Method(() => _ReadInt16(default(TextReader)));
+        public static readonly MethodInfo ReadInt16 = TypedReflection.Method(() => _ReadInt16(default(TextReader)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static short _ReadInt16(TextReader reader)
         {
@@ -231,7 +231,7 @@ namespace Jil.Deserialize
             }
         }
 
-        public static readonly MethodInfo ReadUInt16 = Typesafe.Method(() => _ReadUInt16(default(TextReader)));
+        public static readonly MethodInfo ReadUInt16 = TypedReflection.Method(() => _ReadUInt16(default(TextReader)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static ushort _ReadUInt16(TextReader reader)
         {
@@ -289,7 +289,7 @@ namespace Jil.Deserialize
             }
         }
 
-        public static readonly MethodInfo ReadInt32 = Typesafe.Method(() => _ReadInt32(default(TextReader)));
+        public static readonly MethodInfo ReadInt32 = TypedReflection.Method(() => _ReadInt32(default(TextReader)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static int _ReadInt32(TextReader reader)
         {
@@ -395,7 +395,7 @@ namespace Jil.Deserialize
             }
         }
 
-        public static readonly MethodInfo ReadUInt32 = Typesafe.Method(() => _ReadUInt32(default(TextReader)));
+        public static readonly MethodInfo ReadUInt32 = TypedReflection.Method(() => _ReadUInt32(default(TextReader)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static uint _ReadUInt32(TextReader reader)
         {
@@ -493,7 +493,7 @@ namespace Jil.Deserialize
             }
         }
 
-        public static readonly MethodInfo ReadInt64 = Typesafe.Method(() => _ReadInt64(default(TextReader)));
+        public static readonly MethodInfo ReadInt64 = TypedReflection.Method(() => _ReadInt64(default(TextReader)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static long _ReadInt64(TextReader reader)
         {
@@ -678,7 +678,7 @@ namespace Jil.Deserialize
             }
         }
 
-        public static readonly MethodInfo ReadUInt64 = Typesafe.Method(() => _ReadUInt64(default(TextReader)));
+        public static readonly MethodInfo ReadUInt64 = TypedReflection.Method(() => _ReadUInt64(default(TextReader)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static ulong _ReadUInt64(TextReader reader)
         {
@@ -858,7 +858,7 @@ namespace Jil.Deserialize
             }
         }
 
-        public static readonly MethodInfo ReadDouble = Typesafe.Method((StringBuilder sb) => _ReadDouble(default(TextReader), ref sb));
+        public static readonly MethodInfo ReadDouble = TypedReflection.Method((StringBuilder sb) => _ReadDouble(default(TextReader), ref sb));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static double _ReadDouble(TextReader reader, ref StringBuilder commonSb)
         {
@@ -940,7 +940,7 @@ namespace Jil.Deserialize
             return result;
         }
 
-        public static readonly MethodInfo ReadSingle = Typesafe.Method((StringBuilder sb) => _ReadSingle(default(TextReader), ref sb));
+        public static readonly MethodInfo ReadSingle = TypedReflection.Method((StringBuilder sb) => _ReadSingle(default(TextReader), ref sb));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static float _ReadSingle(TextReader reader, ref StringBuilder commonSb)
         {
@@ -1022,7 +1022,7 @@ namespace Jil.Deserialize
             return result;
         }
 
-        public static readonly MethodInfo ReadDecimal = Typesafe.Method((StringBuilder sb) => _ReadDecimal(default(TextReader), ref sb));
+        public static readonly MethodInfo ReadDecimal = TypedReflection.Method((StringBuilder sb) => _ReadDecimal(default(TextReader), ref sb));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static decimal _ReadDecimal(TextReader reader, ref StringBuilder commonSb)
         {

--- a/Jil/Deserialize/Methods.cs
+++ b/Jil/Deserialize/Methods.cs
@@ -58,7 +58,7 @@ namespace Jil.Deserialize
             public byte B15;
         }
 
-        public static readonly MethodInfo ReadGuid = Typesafe.Method(() => Methods._ReadGuid(default(TextReader)));
+        public static readonly MethodInfo ReadGuid = TypedReflection.Method(() => Methods._ReadGuid(default(TextReader)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static Guid _ReadGuid(TextReader reader)
         {
@@ -169,7 +169,7 @@ namespace Jil.Deserialize
             return (byte)(a * 16 + b);
         }
 
-        public static readonly MethodInfo Skip = Typesafe.Method(() => Methods._Skip(default(TextReader)));
+        public static readonly MethodInfo Skip = TypedReflection.Method(() => Methods._Skip(default(TextReader)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static void _Skip(TextReader reader)
         {
@@ -299,7 +299,7 @@ namespace Jil.Deserialize
             }
         }
 
-        public static MethodInfo SkipEncodedString = Typesafe.Method(() => Methods._SkipEncodedString(default(TextReader)));
+        public static MethodInfo SkipEncodedString = TypedReflection.Method(() => Methods._SkipEncodedString(default(TextReader)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static void _SkipEncodedString(TextReader reader)
         {
@@ -395,7 +395,7 @@ namespace Jil.Deserialize
             }
         }
 
-        public static readonly MethodInfo ConsumeWhiteSpace = Typesafe.Method(() => Methods._ConsumeWhiteSpace(default(TextReader)));
+        public static readonly MethodInfo ConsumeWhiteSpace = TypedReflection.Method(() => Methods._ConsumeWhiteSpace(default(TextReader)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static void _ConsumeWhiteSpace(TextReader reader)
         {
@@ -425,7 +425,7 @@ namespace Jil.Deserialize
                 c == 0x0D;
         }
 
-        public static readonly MethodInfo ReadEncodedString = Typesafe.Method((StringBuilder sb) => Methods._ReadEncodedString(default(TextReader), ref sb));
+        public static readonly MethodInfo ReadEncodedString = TypedReflection.Method((StringBuilder sb) => Methods._ReadEncodedString(default(TextReader), ref sb));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static string _ReadEncodedString(TextReader reader, ref StringBuilder commonSb)
         {
@@ -476,7 +476,7 @@ namespace Jil.Deserialize
             return ret;
         }
 
-        public static readonly MethodInfo ReadEncodedStringWithBuffer = Typesafe.Method((StringBuilder sb) => Methods._ReadEncodedStringWithBuffer(default(TextReader), default(char[]), ref sb));
+        public static readonly MethodInfo ReadEncodedStringWithBuffer = TypedReflection.Method((StringBuilder sb) => Methods._ReadEncodedStringWithBuffer(default(TextReader), default(char[]), ref sb));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static string _ReadEncodedStringWithBuffer(TextReader reader, char[] buffer, ref StringBuilder commonSb)
         {
@@ -584,7 +584,7 @@ namespace Jil.Deserialize
             return ret;
         }
 
-        public static readonly MethodInfo ReadEncodedChar = Typesafe.Method(() => Methods._ReadEncodedChar(default(TextReader)));
+        public static readonly MethodInfo ReadEncodedChar = TypedReflection.Method(() => Methods._ReadEncodedChar(default(TextReader)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static char _ReadEncodedChar(TextReader reader)
         {

--- a/Jil/Deserialize/NameAutomata.cs
+++ b/Jil/Deserialize/NameAutomata.cs
@@ -85,9 +85,9 @@ namespace Jil.Deserialize
             }
         }
 
-        static MethodInfo TextReader_Read = Typesafe.Method((TextReader tr) => tr.Read());
-        static MethodInfo Helper_Consume = Typesafe.Method(() => Helper.Consume(default(TextReader), default(int), default(T)));
-        static MethodInfo Helper_ExpectUnicodeHexQuad = Typesafe.Method(() => Helper.ExpectUnicodeHexQuad(default(TextReader)));
+        static MethodInfo TextReader_Read = TypedReflection.Method((TextReader tr) => tr.Read());
+        static MethodInfo Helper_Consume = TypedReflection.Method(() => Helper.Consume(default(TextReader), default(int), default(T)));
+        static MethodInfo Helper_ExpectUnicodeHexQuad = TypedReflection.Method(() => Helper.ExpectUnicodeHexQuad(default(TextReader)));
 
         static void Recurse(Action<Action> addAction, Emit<Func<TextReader, T>> emit, Label failure, Local local_ch, Label marking, IList<Tuple<string, Action<Emit<Func<TextReader, T>>>>> nameValues, int pos)
         {

--- a/Jil/DeserializeDynamic/DynamicDeserializer.cs
+++ b/Jil/DeserializeDynamic/DynamicDeserializer.cs
@@ -27,7 +27,7 @@ namespace Jil.DeserializeDynamic
             return ret;
         }
 
-        public static MethodInfo DeserializeMember = Typesafe.Method(() => DynamicDeserializer._DeserializeMember(default(TextReader), default(ObjectBuilder)));
+        public static MethodInfo DeserializeMember = TypedReflection.Method(() => DynamicDeserializer._DeserializeMember(default(TextReader), default(ObjectBuilder)));
         static void _DeserializeMember(TextReader reader, ObjectBuilder builder)
         {
             Methods.ConsumeWhiteSpace(reader);

--- a/Jil/DeserializeDynamic/JsonObject.Dynamic.cs
+++ b/Jil/DeserializeDynamic/JsonObject.Dynamic.cs
@@ -23,10 +23,10 @@ namespace Jil.DeserializeDynamic
 
             public JsonMetaObject(JsonObject outer, Expression exp) : base(exp, BindingRestrictions.Empty, outer) { }
 
-            static ConstructorInfo InvalidCastExceptionCons = Typesafe.Constructor(() => new InvalidCastException(default(string)));
-            static MethodInfo StringConcat = Typesafe.Method(() => String.Concat(default(object), default(object), default(object)));
-            static MethodInfo StringConcatArray = Typesafe.Method(() => String.Concat(default(object[])));
-            static MethodInfo StringJoin = Typesafe.Method(() => String.Join(default(string), default(object[])));
+            static ConstructorInfo InvalidCastExceptionCons = TypedReflection.Constructor(() => new InvalidCastException(default(string)));
+            static MethodInfo StringConcat = TypedReflection.Method(() => String.Concat(default(object), default(object), default(object)));
+            static MethodInfo StringConcatArray = TypedReflection.Method(() => String.Concat(default(object[])));
+            static MethodInfo StringJoin = TypedReflection.Method(() => String.Join(default(string), default(object[])));
 
             static ParameterExpression ThisEvaled = Expression.Variable(typeof(JsonObject));
             static ParameterExpression Res = Expression.Variable(typeof(object));
@@ -694,7 +694,7 @@ namespace Jil.DeserializeDynamic
             return false;
         }
 
-        static MethodInfo InnerTryUnaryOperation = Typesafe.Method((JsonObject jo, object o) => jo._InnerTryUnaryOperation(default(ExpressionType), default(Type), out o));
+        static MethodInfo InnerTryUnaryOperation = TypedReflection.Method((JsonObject jo, object o) => jo._InnerTryUnaryOperation(default(ExpressionType), default(Type), out o));
         bool _InnerTryUnaryOperation(ExpressionType operand, Type returnType, out object result)
         {
             switch(operand)
@@ -772,7 +772,7 @@ namespace Jil.DeserializeDynamic
             return false;
         }
 
-        static MethodInfo InnerTryGetIndex = Typesafe.Method((JsonObject jo, object o) => jo._InnerTryGetIndex(default(Type), default(object[]), out o));
+        static MethodInfo InnerTryGetIndex = TypedReflection.Method((JsonObject jo, object o) => jo._InnerTryGetIndex(default(Type), default(object[]), out o));
         bool _InnerTryGetIndex(Type returnType, object[] indexes, out object result)
         {
             if (Type == JsonObjectType.Array)
@@ -846,7 +846,7 @@ namespace Jil.DeserializeDynamic
             return Enumerable.Empty<string>();
         }
 
-        static MethodInfo InnerTryGetMember = Typesafe.Method((JsonObject jo, object o) => jo._InnerTryGetMember(default(string), default(Type), out o));
+        static MethodInfo InnerTryGetMember = TypedReflection.Method((JsonObject jo, object o) => jo._InnerTryGetMember(default(string), default(Type), out o));
         bool _InnerTryGetMember(string name, Type returnType, out object result)
         {
             if (Type == JsonObjectType.Array)
@@ -887,7 +887,7 @@ namespace Jil.DeserializeDynamic
             return ret;
         }
 
-        static MethodInfo InnerTryConvertMtd = Typesafe.Method((JsonObject jo, object o) => jo.InnerTryConvert(default(Type), out o));
+        static MethodInfo InnerTryConvertMtd = TypedReflection.Method((JsonObject jo, object o) => jo.InnerTryConvert(default(Type), out o));
         bool InnerTryConvert(Type returnType, out object result)
         {
             if (returnType == typeof(object))
@@ -1296,7 +1296,7 @@ namespace Jil.DeserializeDynamic
             return true;
         }
 
-        static MethodInfo InnerTryInvokeMember = Typesafe.Method((JsonObject jo, object o) => jo._InnerTryInvokeMember(default(string), default(object[]), out o));
+        static MethodInfo InnerTryInvokeMember = TypedReflection.Method((JsonObject jo, object o) => jo._InnerTryInvokeMember(default(string), default(object[]), out o));
         bool _InnerTryInvokeMember(string name, object[] args, out object result)
         {
             if (name == "ToString" && args.Length == 0)

--- a/Jil/DeserializeDynamic/ObjectBuilder.cs
+++ b/Jil/DeserializeDynamic/ObjectBuilder.cs
@@ -25,7 +25,7 @@ namespace Jil.DeserializeDynamic
             }
         }
 
-        public static FieldInfo _BeingBuilt = Typesafe.Field((ObjectBuilder ob) => ob.BeingBuilt);
+        public static FieldInfo _BeingBuilt = TypedReflection.Field((ObjectBuilder ob) => ob.BeingBuilt);
         public JsonObject BeingBuilt;
 
         public ObjectBuilder(Options options)

--- a/Jil/Jil.csproj
+++ b/Jil/Jil.csproj
@@ -63,7 +63,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Common\ConstructionException.cs" />
-    <Compile Include="Common\Typesafe.cs" />
+    <Compile Include="Common\TypedReflection.cs" />
     <Compile Include="DateTimeFormat.cs" />
     <Compile Include="DeserializationException.cs" />
     <Compile Include="DeserializeDynamic\DynamicDeserializer.cs" />

--- a/Jil/Serialize/InlineSerializer.cs
+++ b/Jil/Serialize/InlineSerializer.cs
@@ -108,7 +108,7 @@ namespace Jil.Serialize
             }
         }
 
-        static MethodInfo TextWriter_WriteString = Typesafe.Method((TextWriter tw) => tw.Write(default(string)));
+        static MethodInfo TextWriter_WriteString = TypedReflection.Method((TextWriter tw) => tw.Write(default(string)));
         void WriteString(string str)
         {
             Emit.LoadArgument(0);
@@ -494,7 +494,7 @@ namespace Jil.Serialize
             //   - DateTime
             //   - TextWriter
 
-            var toUniversalTime = Typesafe.Method((DateTime dt) => dt.ToUniversalTime());
+            var toUniversalTime = TypedReflection.Method((DateTime dt) => dt.ToUniversalTime());
 
             using (var loc = Emit.DeclareLocal<DateTime>())
             {
@@ -507,9 +507,9 @@ namespace Jil.Serialize
 
             if (!SkipDateTimeMathMethods)
             {
-                var subtractMtd = Typesafe.Method((DateTime dt) => dt.Subtract(default(DateTime)));
-                var totalMs = Typesafe.Property((TimeSpan ts) => ts.TotalMilliseconds);
-                var dtCons = Typesafe.Constructor(() => new DateTime(default(int), default(int), default(int), default(int), default(int), default(int), default(DateTimeKind)));
+                var subtractMtd = TypedReflection.Method((DateTime dt) => dt.Subtract(default(DateTime)));
+                var totalMs = TypedReflection.Property((TimeSpan ts) => ts.TotalMilliseconds);
+                var dtCons = TypedReflection.Constructor(() => new DateTime(default(int), default(int), default(int), default(int), default(int), default(int), default(DateTimeKind)));
 
                 Emit.LoadConstant(1970);                    // TextWriter DateTime* 1970
                 Emit.LoadConstant(1);                       // TextWriter DateTime* 1970 1
@@ -537,7 +537,7 @@ namespace Jil.Serialize
                 return;
             }
 
-            var getTicks = Typesafe.Property((DateTime dt) => dt.Ticks);
+            var getTicks = TypedReflection.Property((DateTime dt) => dt.Ticks);
 
             LoadProperty(getTicks);                         // TextWriter long
             Emit.LoadConstant(621355968000000000L);         // TextWriter long (Unix Epoch Ticks long)
@@ -552,7 +552,7 @@ namespace Jil.Serialize
 
         void WriteMillisecondsStyleDateTime()
         {
-            var toUniversalTime = Typesafe.Method((DateTime dt) => dt.ToUniversalTime());
+            var toUniversalTime = TypedReflection.Method((DateTime dt) => dt.ToUniversalTime());
 
             using (var loc = Emit.DeclareLocal<DateTime>())
             {
@@ -565,9 +565,9 @@ namespace Jil.Serialize
 
             if (!SkipDateTimeMathMethods)
             {
-                var subtractMtd = Typesafe.Method((DateTime dt) => dt.Subtract(default(DateTime)));
-                var totalMs = Typesafe.Property((TimeSpan ts) => ts.TotalMilliseconds);
-                var dtCons = Typesafe.Constructor(() => new DateTime(default(int), default(int), default(int), default(int), default(int), default(int), default(DateTimeKind)));
+                var subtractMtd = TypedReflection.Method((DateTime dt) => dt.Subtract(default(DateTime)));
+                var totalMs = TypedReflection.Property((TimeSpan ts) => ts.TotalMilliseconds);
+                var dtCons = TypedReflection.Constructor(() => new DateTime(default(int), default(int), default(int), default(int), default(int), default(int), default(DateTimeKind)));
 
                 Emit.LoadConstant(1970);                    // TextWriter DateTime* 1970
                 Emit.LoadConstant(1);                       // TextWriter DateTime* 1970 1
@@ -593,7 +593,7 @@ namespace Jil.Serialize
                 return;
             }
 
-            var getTicks = Typesafe.Property((DateTime ts) => ts.Ticks); 
+            var getTicks = TypedReflection.Property((DateTime ts) => ts.Ticks); 
 
             LoadProperty(getTicks);                         // TextWriter long
             Emit.LoadConstant(621355968000000000L);         // TextWriter long (Unix Epoch Ticks long)
@@ -606,7 +606,7 @@ namespace Jil.Serialize
 
         void WriteSecondsStyleDateTime()
         {
-            var toUniversalTime = Typesafe.Method((DateTime dt) => dt.ToUniversalTime());
+            var toUniversalTime = TypedReflection.Method((DateTime dt) => dt.ToUniversalTime());
 
             using (var loc = Emit.DeclareLocal<DateTime>())
             {
@@ -619,10 +619,10 @@ namespace Jil.Serialize
 
             if (!SkipDateTimeMathMethods)
             {
-                var subtractMtd = Typesafe.Method((DateTime dt) => dt.Subtract(default(DateTime)));
+                var subtractMtd = TypedReflection.Method((DateTime dt) => dt.Subtract(default(DateTime)));
 
-                var totalS = Typesafe.Property((TimeSpan ts) => ts.TotalSeconds);
-                var dtCons = Typesafe.Constructor(() => new DateTime(default(int), default(int), default(int), default(int), default(int), default(int), default(DateTimeKind)));
+                var totalS = TypedReflection.Property((TimeSpan ts) => ts.TotalSeconds);
+                var dtCons = TypedReflection.Constructor(() => new DateTime(default(int), default(int), default(int), default(int), default(int), default(int), default(DateTimeKind)));
 
                 Emit.LoadConstant(1970);                    // TextWriter DateTime* 1970
                 Emit.LoadConstant(1);                       // TextWriter DateTime* 1970 1
@@ -648,7 +648,7 @@ namespace Jil.Serialize
                 return;
             }
 
-            var getTicks = Typesafe.Property((DateTime ts) => ts.Ticks);
+            var getTicks = TypedReflection.Property((DateTime ts) => ts.Ticks);
 
             LoadProperty(getTicks);                         // TextWriter long
             Emit.LoadConstant(621355968000000000L);         // TextWriter long (Unix Epoch Ticks long)
@@ -665,11 +665,11 @@ namespace Jil.Serialize
             //  - DateTime
             //  - TextWriter
 
-            var toUniversalTime = Typesafe.Method((DateTime dt) => dt.ToUniversalTime());
+            var toUniversalTime = TypedReflection.Method((DateTime dt) => dt.ToUniversalTime());
 
             if (!UseCustomISODateFormatting)
             {
-                var toString = Typesafe.Method((DateTime dt) => dt.ToString(default(string)));
+                var toString = TypedReflection.Method((DateTime dt) => dt.ToString(default(string)));
 
                 using (var loc = Emit.DeclareLocal<DateTime>())
                 {
@@ -695,7 +695,7 @@ namespace Jil.Serialize
             Emit.Call(Methods.CustomISO8601ToString);       // --empty--
         }
 
-        static readonly MethodInfo DateTimeOffset_UtcDateTime = Typesafe.PropertyGet((DateTimeOffset dto) => dto.UtcDateTime);
+        static readonly MethodInfo DateTimeOffset_UtcDateTime = TypedReflection.PropertyGet((DateTimeOffset dto) => dto.UtcDateTime);
         void WriteDateTimeOffset()
         {
             // top of stack:
@@ -973,7 +973,7 @@ namespace Jil.Serialize
             //  - char
             //  - TextWriter
 
-            var writeChar = Typesafe.Method((TextWriter tw) => tw.Write(default(char)));
+            var writeChar = TypedReflection.Method((TextWriter tw) => tw.Write(default(char)));
 
             var lowestCharNeedingEncoding = (int)CharacterEscapes.Keys.OrderBy(c => (int)c).First();
 

--- a/Jil/Serialize/Methods.cs
+++ b/Jil/Serialize/Methods.cs
@@ -96,7 +96,7 @@ namespace Jil.Serialize
 
         static readonly char[] WriteGuidLookup = new char[] { '0', '0', '0', '1', '0', '2', '0', '3', '0', '4', '0', '5', '0', '6', '0', '7', '0', '8', '0', '9', '0', 'a', '0', 'b', '0', 'c', '0', 'd', '0', 'e', '0', 'f', '1', '0', '1', '1', '1', '2', '1', '3', '1', '4', '1', '5', '1', '6', '1', '7', '1', '8', '1', '9', '1', 'a', '1', 'b', '1', 'c', '1', 'd', '1', 'e', '1', 'f', '2', '0', '2', '1', '2', '2', '2', '3', '2', '4', '2', '5', '2', '6', '2', '7', '2', '8', '2', '9', '2', 'a', '2', 'b', '2', 'c', '2', 'd', '2', 'e', '2', 'f', '3', '0', '3', '1', '3', '2', '3', '3', '3', '4', '3', '5', '3', '6', '3', '7', '3', '8', '3', '9', '3', 'a', '3', 'b', '3', 'c', '3', 'd', '3', 'e', '3', 'f', '4', '0', '4', '1', '4', '2', '4', '3', '4', '4', '4', '5', '4', '6', '4', '7', '4', '8', '4', '9', '4', 'a', '4', 'b', '4', 'c', '4', 'd', '4', 'e', '4', 'f', '5', '0', '5', '1', '5', '2', '5', '3', '5', '4', '5', '5', '5', '6', '5', '7', '5', '8', '5', '9', '5', 'a', '5', 'b', '5', 'c', '5', 'd', '5', 'e', '5', 'f', '6', '0', '6', '1', '6', '2', '6', '3', '6', '4', '6', '5', '6', '6', '6', '7', '6', '8', '6', '9', '6', 'a', '6', 'b', '6', 'c', '6', 'd', '6', 'e', '6', 'f', '7', '0', '7', '1', '7', '2', '7', '3', '7', '4', '7', '5', '7', '6', '7', '7', '7', '8', '7', '9', '7', 'a', '7', 'b', '7', 'c', '7', 'd', '7', 'e', '7', 'f', '8', '0', '8', '1', '8', '2', '8', '3', '8', '4', '8', '5', '8', '6', '8', '7', '8', '8', '8', '9', '8', 'a', '8', 'b', '8', 'c', '8', 'd', '8', 'e', '8', 'f', '9', '0', '9', '1', '9', '2', '9', '3', '9', '4', '9', '5', '9', '6', '9', '7', '9', '8', '9', '9', '9', 'a', '9', 'b', '9', 'c', '9', 'd', '9', 'e', '9', 'f', 'a', '0', 'a', '1', 'a', '2', 'a', '3', 'a', '4', 'a', '5', 'a', '6', 'a', '7', 'a', '8', 'a', '9', 'a', 'a', 'a', 'b', 'a', 'c', 'a', 'd', 'a', 'e', 'a', 'f', 'b', '0', 'b', '1', 'b', '2', 'b', '3', 'b', '4', 'b', '5', 'b', '6', 'b', '7', 'b', '8', 'b', '9', 'b', 'a', 'b', 'b', 'b', 'c', 'b', 'd', 'b', 'e', 'b', 'f', 'c', '0', 'c', '1', 'c', '2', 'c', '3', 'c', '4', 'c', '5', 'c', '6', 'c', '7', 'c', '8', 'c', '9', 'c', 'a', 'c', 'b', 'c', 'c', 'c', 'd', 'c', 'e', 'c', 'f', 'd', '0', 'd', '1', 'd', '2', 'd', '3', 'd', '4', 'd', '5', 'd', '6', 'd', '7', 'd', '8', 'd', '9', 'd', 'a', 'd', 'b', 'd', 'c', 'd', 'd', 'd', 'e', 'd', 'f', 'e', '0', 'e', '1', 'e', '2', 'e', '3', 'e', '4', 'e', '5', 'e', '6', 'e', '7', 'e', '8', 'e', '9', 'e', 'a', 'e', 'b', 'e', 'c', 'e', 'd', 'e', 'e', 'e', 'f', 'f', '0', 'f', '1', 'f', '2', 'f', '3', 'f', '4', 'f', '5', 'f', '6', 'f', '7', 'f', '8', 'f', '9', 'f', 'a', 'f', 'b', 'f', 'c', 'f', 'd', 'f', 'e', 'f', 'f' };
 
-        internal static readonly MethodInfo WriteGuid = Typesafe.Method(() => _WriteGuid(default(TextWriter), default(Guid), default(char[])));
+        internal static readonly MethodInfo WriteGuid = TypedReflection.Method(() => _WriteGuid(default(TextWriter), default(Guid), default(char[])));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static void _WriteGuid(TextWriter writer, Guid guid, char[] buffer)
         {
@@ -220,7 +220,7 @@ namespace Jil.Serialize
             writer.Write(buffer, 0, 36);
         }
 
-        internal static readonly MethodInfo CustomISO8601ToString = Typesafe.Method(() => _CustomISO8601ToString(default(TextWriter), default(DateTime), default(char[])));
+        internal static readonly MethodInfo CustomISO8601ToString = TypedReflection.Method(() => _CustomISO8601ToString(default(TextWriter), default(DateTime), default(char[])));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static void _CustomISO8601ToString(TextWriter writer, DateTime dt, char[] buffer)
         {
@@ -358,7 +358,7 @@ namespace Jil.Serialize
             writer.Write(buffer, 0, fracEnd + 2);
         }
 
-        internal static readonly MethodInfo WriteEncodedStringWithQuotesWithoutNullsInlineUnsafe = Typesafe.Method(() => _WriteEncodedStringWithQuotesWithoutNullsInlineUnsafe(default(TextWriter), default(string)));
+        internal static readonly MethodInfo WriteEncodedStringWithQuotesWithoutNullsInlineUnsafe = TypedReflection.Method(() => _WriteEncodedStringWithQuotesWithoutNullsInlineUnsafe(default(TextWriter), default(string)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static unsafe void _WriteEncodedStringWithQuotesWithoutNullsInlineUnsafe(TextWriter writer, string strRef)
         {
@@ -433,7 +433,7 @@ namespace Jil.Serialize
             writer.Write("\"");
         }
 
-        internal static readonly MethodInfo WriteEncodedStringWithQuotesWithoutNullsInlineJSONPUnsafe = Typesafe.Method(() => _WriteEncodedStringWithQuotesWithoutNullsInlineJSONPUnsafe(default(TextWriter), default(string)));
+        internal static readonly MethodInfo WriteEncodedStringWithQuotesWithoutNullsInlineJSONPUnsafe = TypedReflection.Method(() => _WriteEncodedStringWithQuotesWithoutNullsInlineJSONPUnsafe(default(TextWriter), default(string)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static unsafe void _WriteEncodedStringWithQuotesWithoutNullsInlineJSONPUnsafe(TextWriter writer, string strRef)
         {
@@ -520,7 +520,7 @@ namespace Jil.Serialize
             writer.Write("\"");
         }
 
-        internal static readonly MethodInfo WriteEncodedStringWithQuotesWithNullsInlineUnsafe = Typesafe.Method(() => _WriteEncodedStringWithQuotesWithNullsInlineUnsafe(default(TextWriter), default(string)));
+        internal static readonly MethodInfo WriteEncodedStringWithQuotesWithNullsInlineUnsafe = TypedReflection.Method(() => _WriteEncodedStringWithQuotesWithNullsInlineUnsafe(default(TextWriter), default(string)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static unsafe void _WriteEncodedStringWithQuotesWithNullsInlineUnsafe(TextWriter writer, string strRef)
         {
@@ -599,7 +599,7 @@ namespace Jil.Serialize
             writer.Write("\"");
         }
 
-        internal static readonly MethodInfo WriteEncodedStringWithQuotesWithNullsInlineJSONPUnsafe = Typesafe.Method(() => _WriteEncodedStringWithQuotesWithNullsInlineJSONPUnsafe(default(TextWriter), default(string)));
+        internal static readonly MethodInfo WriteEncodedStringWithQuotesWithNullsInlineJSONPUnsafe = TypedReflection.Method(() => _WriteEncodedStringWithQuotesWithNullsInlineJSONPUnsafe(default(TextWriter), default(string)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static unsafe void _WriteEncodedStringWithQuotesWithNullsInlineJSONPUnsafe(TextWriter writer, string strRef)
         {
@@ -690,7 +690,7 @@ namespace Jil.Serialize
             writer.Write("\"");
         }
 
-        internal static readonly MethodInfo WriteEncodedStringWithoutNullsInlineUnsafe = Typesafe.Method(() => _WriteEncodedStringWithoutNullsInlineUnsafe(default(TextWriter), default(string)));
+        internal static readonly MethodInfo WriteEncodedStringWithoutNullsInlineUnsafe = TypedReflection.Method(() => _WriteEncodedStringWithoutNullsInlineUnsafe(default(TextWriter), default(string)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static unsafe void _WriteEncodedStringWithoutNullsInlineUnsafe(TextWriter writer, string strRef)
         {
@@ -761,7 +761,7 @@ namespace Jil.Serialize
             }
         }
 
-        internal static readonly MethodInfo WriteEncodedStringWithoutNullsInlineJSONPUnsafe = Typesafe.Method(() => _WriteEncodedStringWithoutNullsInlineJSONPUnsafe(default(TextWriter), default(string)));
+        internal static readonly MethodInfo WriteEncodedStringWithoutNullsInlineJSONPUnsafe = TypedReflection.Method(() => _WriteEncodedStringWithoutNullsInlineJSONPUnsafe(default(TextWriter), default(string)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static unsafe void _WriteEncodedStringWithoutNullsInlineJSONPUnsafe(TextWriter writer, string strRef)
         {
@@ -844,7 +844,7 @@ namespace Jil.Serialize
             }
         }
 
-        internal static readonly MethodInfo WriteEncodedStringWithNullsInlineJSONPUnsafe = Typesafe.Method(() => _WriteEncodedStringWithNullsInlineJSONPUnsafe(default(TextWriter), default(string)));
+        internal static readonly MethodInfo WriteEncodedStringWithNullsInlineJSONPUnsafe = TypedReflection.Method(() => _WriteEncodedStringWithNullsInlineJSONPUnsafe(default(TextWriter), default(string)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static unsafe void _WriteEncodedStringWithNullsInlineJSONPUnsafe(TextWriter writer, string strRef)
         {
@@ -931,7 +931,7 @@ namespace Jil.Serialize
             }
         }
 
-        internal static readonly MethodInfo WriteEncodedStringWithNullsInlineUnsafe = Typesafe.Method(() => _WriteEncodedStringWithNullsInlineUnsafe(default(TextWriter), default(string)));
+        internal static readonly MethodInfo WriteEncodedStringWithNullsInlineUnsafe = TypedReflection.Method(() => _WriteEncodedStringWithNullsInlineUnsafe(default(TextWriter), default(string)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static unsafe void _WriteEncodedStringWithNullsInlineUnsafe(TextWriter writer, string strRef)
         {
@@ -1006,7 +1006,7 @@ namespace Jil.Serialize
             }
         }
 
-        internal static readonly MethodInfo CustomWriteInt = Typesafe.Method(() => _CustomWriteInt(default(TextWriter), default(int), default(char[])));
+        internal static readonly MethodInfo CustomWriteInt = TypedReflection.Method(() => _CustomWriteInt(default(TextWriter), default(int), default(char[])));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static void _CustomWriteInt(TextWriter writer, int number, char[] buffer)
         {
@@ -1048,7 +1048,7 @@ namespace Jil.Serialize
             writer.Write(buffer, ptr + 1, InlineSerializer<object>.CharBufferSize - 1 - ptr);
         }
 
-        internal static readonly MethodInfo CustomWriteIntUnrolledSigned = Typesafe.Method(() => _CustomWriteIntUnrolledSigned(default(TextWriter), default(int), default(char[])));
+        internal static readonly MethodInfo CustomWriteIntUnrolledSigned = TypedReflection.Method(() => _CustomWriteIntUnrolledSigned(default(TextWriter), default(int), default(char[])));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static void _CustomWriteIntUnrolledSigned(TextWriter writer, int num, char[] buffer)
         {
@@ -1201,7 +1201,7 @@ namespace Jil.Serialize
             writer.Write(buffer, 10 - numLen, numLen);
         }
 
-        internal static readonly MethodInfo CustomWriteUInt = Typesafe.Method(() => _CustomWriteUInt(default(TextWriter), default(uint), default(char[])));
+        internal static readonly MethodInfo CustomWriteUInt = TypedReflection.Method(() => _CustomWriteUInt(default(TextWriter), default(uint), default(char[])));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static void _CustomWriteUInt(TextWriter writer, uint number, char[] buffer)
         {
@@ -1227,7 +1227,7 @@ namespace Jil.Serialize
             writer.Write(buffer, ptr + 1, InlineSerializer<object>.CharBufferSize - 1 - ptr);
         }
 
-        internal static readonly MethodInfo CustomWriteUIntUnrolled = Typesafe.Method(() => _CustomWriteUIntUnrolled(default(TextWriter), default(uint), default(char[])));
+        internal static readonly MethodInfo CustomWriteUIntUnrolled = TypedReflection.Method(() => _CustomWriteUIntUnrolled(default(TextWriter), default(uint), default(char[])));
         static void _CustomWriteUIntUnrolled(TextWriter writer, uint number, char[] buffer)
         {
             int numLen;
@@ -1333,7 +1333,7 @@ namespace Jil.Serialize
             writer.Write(buffer, 10 - numLen, numLen);
         }
 
-        internal static readonly MethodInfo CustomWriteLong = Typesafe.Method(() => _CustomWriteLong(default(TextWriter), default(long), default(char[])));
+        internal static readonly MethodInfo CustomWriteLong = TypedReflection.Method(() => _CustomWriteLong(default(TextWriter), default(long), default(char[])));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static void _CustomWriteLong(TextWriter writer, long number, char[] buffer)
         {
@@ -1375,7 +1375,7 @@ namespace Jil.Serialize
             writer.Write(buffer, ptr + 1, InlineSerializer<object>.CharBufferSize - 1 - ptr);
         }
 
-        internal static readonly MethodInfo CustomWriteULong = Typesafe.Method(() => _CustomWriteULong(default(TextWriter), default(ulong), default(char[])));
+        internal static readonly MethodInfo CustomWriteULong = TypedReflection.Method(() => _CustomWriteULong(default(TextWriter), default(ulong), default(char[])));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static void _CustomWriteULong(TextWriter writer, ulong number, char[] buffer)
         {
@@ -1401,7 +1401,7 @@ namespace Jil.Serialize
             writer.Write(buffer, ptr + 1, InlineSerializer<object>.CharBufferSize - 1 - ptr);
         }
 
-        internal static readonly MethodInfo ProxyFloat = Typesafe.Method(() => _ProxyFloat(default(TextWriter), default(float)));
+        internal static readonly MethodInfo ProxyFloat = TypedReflection.Method(() => _ProxyFloat(default(TextWriter), default(float)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static void _ProxyFloat(TextWriter writer, float f)
         {
@@ -1417,7 +1417,7 @@ namespace Jil.Serialize
             writer.Write(f.ToString(invariant));
         }
 
-        internal static readonly MethodInfo ProxyDouble = Typesafe.Method(() => _ProxyDouble(default(TextWriter), default(double)));
+        internal static readonly MethodInfo ProxyDouble = TypedReflection.Method(() => _ProxyDouble(default(TextWriter), default(double)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static void _ProxyDouble(TextWriter writer, double d)
         {
@@ -1433,7 +1433,7 @@ namespace Jil.Serialize
             writer.Write(d.ToString(invariant));
         }
 
-        internal static readonly MethodInfo ProxyDecimal = Typesafe.Method(() => _ProxyDecimal(default(TextWriter), default(decimal)));
+        internal static readonly MethodInfo ProxyDecimal = TypedReflection.Method(() => _ProxyDecimal(default(TextWriter), default(decimal)));
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static void _ProxyDecimal(TextWriter writer, decimal d)
         {

--- a/Jil/SerializeDynamic/DynamicSerializer.cs
+++ b/Jil/SerializeDynamic/DynamicSerializer.cs
@@ -567,7 +567,7 @@ namespace Jil.SerializeDynamic
             return false;
         }
 
-        public static readonly MethodInfo SerializeMtd = Typesafe.Method(() => Serialize(default(TextWriter), default(object), default(Options), default(int)));
+        public static readonly MethodInfo SerializeMtd = TypedReflection.Method(() => Serialize(default(TextWriter), default(object), default(Options), default(int)));
         public static void Serialize(TextWriter stream, object obj, Options opts, int depth)
         {
             if (obj == null)

--- a/Jil/SerializeDynamic/RecursiveSerializerCache.cs
+++ b/Jil/SerializeDynamic/RecursiveSerializerCache.cs
@@ -15,7 +15,7 @@ namespace Jil.SerializeDynamic
     {
         static readonly Hashtable Cache = new Hashtable();
 
-        public static readonly MethodInfo GetFor = Typesafe.Method(() => _GetFor(default(bool), default(bool), default(bool), default(DateTimeFormat), default(bool)));
+        public static readonly MethodInfo GetFor = TypedReflection.Method(() => _GetFor(default(bool), default(bool), default(bool), default(DateTimeFormat), default(bool)));
         static Action<TextWriter, T, int> _GetFor(
                 bool prettyPrint, 
                 bool excludeNulls, 

--- a/JilTests/UtilsTests.cs
+++ b/JilTests/UtilsTests.cs
@@ -29,12 +29,12 @@ namespace JilTests
             var offset = Utils.FieldOffsetsInMemory(typeof(_FieldOffsetsInMemory));
             
             Assert.IsNotNull(offset);
-            Assert.IsTrue(offset.ContainsKey(Typesafe.Field((_FieldOffsetsInMemory fom) => fom.Foo)));
-            Assert.IsTrue(offset.ContainsKey(Typesafe.Field((_FieldOffsetsInMemory fom) => fom.Bar)));
-            Assert.IsTrue(offset.ContainsKey(Typesafe.Field((_FieldOffsetsInMemory fom) => fom.Fizz)));
-            Assert.IsTrue(offset.ContainsKey(Typesafe.Field((_FieldOffsetsInMemory fom) => fom.Buzz)));
-            Assert.IsTrue(offset.ContainsKey(Typesafe.Field((_FieldOffsetsInMemory fom) => fom.Hello)));
-            Assert.IsTrue(offset.ContainsKey(Typesafe.Field((_FieldOffsetsInMemory fom) => fom.World)));
+            Assert.IsTrue(offset.ContainsKey(TypedReflection.Field((_FieldOffsetsInMemory fom) => fom.Foo)));
+            Assert.IsTrue(offset.ContainsKey(TypedReflection.Field((_FieldOffsetsInMemory fom) => fom.Bar)));
+            Assert.IsTrue(offset.ContainsKey(TypedReflection.Field((_FieldOffsetsInMemory fom) => fom.Fizz)));
+            Assert.IsTrue(offset.ContainsKey(TypedReflection.Field((_FieldOffsetsInMemory fom) => fom.Buzz)));
+            Assert.IsTrue(offset.ContainsKey(TypedReflection.Field((_FieldOffsetsInMemory fom) => fom.Hello)));
+            Assert.IsTrue(offset.ContainsKey(TypedReflection.Field((_FieldOffsetsInMemory fom) => fom.World)));
         }
 
 #pragma warning disable 0649
@@ -72,12 +72,12 @@ namespace JilTests
             var use = Utils.PropertyFieldUsage(typeof(_PropertyFieldUsage));
             
             Assert.IsNotNull(use);
-            Assert.AreEqual(1, use[Typesafe.Property((_PropertyFieldUsage pfu) => pfu.Foo)].Count);
-            Assert.AreEqual(typeof(_PropertyFieldUsage).GetField("_Foo", BindingFlags.NonPublic | BindingFlags.Instance), use[Typesafe.Property((_PropertyFieldUsage pfu) => pfu.Foo)][0]);
+            Assert.AreEqual(1, use[TypedReflection.Property((_PropertyFieldUsage pfu) => pfu.Foo)].Count);
+            Assert.AreEqual(typeof(_PropertyFieldUsage).GetField("_Foo", BindingFlags.NonPublic | BindingFlags.Instance), use[TypedReflection.Property((_PropertyFieldUsage pfu) => pfu.Foo)][0]);
 
-            Assert.AreEqual(2, use[Typesafe.Property((_PropertyFieldUsage pfu) => pfu.SomeProp)].Count);
-            Assert.AreEqual(typeof(_PropertyFieldUsage).GetField("_Foo", BindingFlags.NonPublic | BindingFlags.Instance), use[Typesafe.Property((_PropertyFieldUsage pfu) => pfu.SomeProp)][0]);
-            Assert.AreEqual(typeof(_PropertyFieldUsage).GetField("_Scaler", BindingFlags.NonPublic | BindingFlags.Instance), use[Typesafe.Property((_PropertyFieldUsage pfu) => pfu.SomeProp)][1]);
+            Assert.AreEqual(2, use[TypedReflection.Property((_PropertyFieldUsage pfu) => pfu.SomeProp)].Count);
+            Assert.AreEqual(typeof(_PropertyFieldUsage).GetField("_Foo", BindingFlags.NonPublic | BindingFlags.Instance), use[TypedReflection.Property((_PropertyFieldUsage pfu) => pfu.SomeProp)][0]);
+            Assert.AreEqual(typeof(_PropertyFieldUsage).GetField("_Scaler", BindingFlags.NonPublic | BindingFlags.Instance), use[TypedReflection.Property((_PropertyFieldUsage pfu) => pfu.SomeProp)][1]);
         }
 
         private static string CapacityEstimatorToString<T>(Action<TextWriter, T, int> act, T data)
@@ -197,65 +197,65 @@ namespace JilTests
         [TestMethod]
         public void ConstantProperties()
         {
-            Assert.AreEqual("\" \"", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.C1), false));
-            Assert.AreEqual("\"\\\"\"", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.C2), false));
+            Assert.AreEqual("\" \"", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.C1), false));
+            Assert.AreEqual("\"\\\"\"", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.C2), false));
 
-            Assert.AreEqual("null", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.STR1), false));
-            Assert.AreEqual("\"hello world\"", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.STR2), false));
-            Assert.AreEqual(@"""\r\n\f""", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.STR3), false));
+            Assert.AreEqual("null", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.STR1), false));
+            Assert.AreEqual("\"hello world\"", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.STR2), false));
+            Assert.AreEqual(@"""\r\n\f""", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.STR3), false));
 
-            Assert.AreEqual("true", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.BOOL1), false));
-            Assert.AreEqual("false", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.BOOL2), false));
+            Assert.AreEqual("true", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.BOOL1), false));
+            Assert.AreEqual("false", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.BOOL2), false));
 
-            Assert.AreEqual("0", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.B1), false));
-            Assert.AreEqual("127", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.B2), false));
-            Assert.AreEqual("255", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.B3), false));
+            Assert.AreEqual("0", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.B1), false));
+            Assert.AreEqual("127", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.B2), false));
+            Assert.AreEqual("255", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.B3), false));
 
-            Assert.AreEqual("-128", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.SB1), false));
-            Assert.AreEqual("0", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.SB2), false));
-            Assert.AreEqual("127", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.SB3), false));
+            Assert.AreEqual("-128", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.SB1), false));
+            Assert.AreEqual("0", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.SB2), false));
+            Assert.AreEqual("127", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.SB3), false));
 
-            Assert.AreEqual("-32768", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.S1), false));
-            Assert.AreEqual("0", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.S2), false));
-            Assert.AreEqual("32767", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.S3), false));
+            Assert.AreEqual("-32768", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.S1), false));
+            Assert.AreEqual("0", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.S2), false));
+            Assert.AreEqual("32767", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.S3), false));
 
-            Assert.AreEqual("0", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.US1), false));
-            Assert.AreEqual("32767", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.US2), false));
-            Assert.AreEqual("65535", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.US3), false));
+            Assert.AreEqual("0", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.US1), false));
+            Assert.AreEqual("32767", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.US2), false));
+            Assert.AreEqual("65535", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.US3), false));
 
-            Assert.AreEqual("-2147483648", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.I1), false));
-            Assert.AreEqual("0", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.I2), false));
-            Assert.AreEqual("2147483647", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.I3), false));
+            Assert.AreEqual("-2147483648", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.I1), false));
+            Assert.AreEqual("0", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.I2), false));
+            Assert.AreEqual("2147483647", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.I3), false));
 
-            Assert.AreEqual("0", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.UI1), false));
-            Assert.AreEqual("2147483647", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.UI2), false));
-            Assert.AreEqual("4294967295", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.UI3), false));
+            Assert.AreEqual("0", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.UI1), false));
+            Assert.AreEqual("2147483647", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.UI2), false));
+            Assert.AreEqual("4294967295", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.UI3), false));
 
-            Assert.AreEqual("-9223372036854775808", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.L1), false));
-            Assert.AreEqual("0", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.L2), false));
-            Assert.AreEqual("9223372036854775807", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.L3), false));
+            Assert.AreEqual("-9223372036854775808", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.L1), false));
+            Assert.AreEqual("0", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.L2), false));
+            Assert.AreEqual("9223372036854775807", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.L3), false));
 
-            Assert.AreEqual("0", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.UL1), false));
-            Assert.AreEqual("9223372036854775807", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.UL2), false));
-            Assert.AreEqual("18446744073709551615", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.UL3), false));
-            Assert.AreEqual("18446744073709551614", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.UL4), false));
+            Assert.AreEqual("0", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.UL1), false));
+            Assert.AreEqual("9223372036854775807", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.UL2), false));
+            Assert.AreEqual("18446744073709551615", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.UL3), false));
+            Assert.AreEqual("18446744073709551614", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.UL4), false));
 
-            Assert.AreEqual("-1234.56", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.F1), false));
-            Assert.AreEqual("0", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.F2), false));
-            Assert.AreEqual("1234.56", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.F3), false));
+            Assert.AreEqual("-1234.56", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.F1), false));
+            Assert.AreEqual("0", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.F2), false));
+            Assert.AreEqual("1234.56", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.F3), false));
 
-            Assert.AreEqual("-1234.56", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.D1), false));
-            Assert.AreEqual("0", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.D2), false));
-            Assert.AreEqual("1234.56", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.D3), false));
+            Assert.AreEqual("-1234.56", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.D1), false));
+            Assert.AreEqual("0", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.D2), false));
+            Assert.AreEqual("1234.56", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.D3), false));
 
-            Assert.AreEqual("\"A\"", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.BE), false));
-            Assert.AreEqual("\"A\"", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.SBE), false));
-            Assert.AreEqual("\"A\"", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.SE), false));
-            Assert.AreEqual("\"A\"", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.USE), false));
-            Assert.AreEqual("\"A\"", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.IE), false));
-            Assert.AreEqual("\"A\"", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.UIE), false));
-            Assert.AreEqual("\"A\"", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.LE), false));
-            Assert.AreEqual("\"A\"", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(Typesafe.Property((_ConstantProperties cp) => cp.ULE), false));
+            Assert.AreEqual("\"A\"", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.BE), false));
+            Assert.AreEqual("\"A\"", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.SBE), false));
+            Assert.AreEqual("\"A\"", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.SE), false));
+            Assert.AreEqual("\"A\"", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.USE), false));
+            Assert.AreEqual("\"A\"", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.IE), false));
+            Assert.AreEqual("\"A\"", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.UIE), false));
+            Assert.AreEqual("\"A\"", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.LE), false));
+            Assert.AreEqual("\"A\"", Jil.Common.ExtensionMethods.GetConstantJSONStringEquivalent(TypedReflection.Property((_ConstantProperties cp) => cp.ULE), false));
         }
 
         class _ConstantFields


### PR DESCRIPTION
No performance increases here, rather just some assistance for code maintenance. Uses the c# lambda expression syntax to describe MethodInfo, PropertyInfo, FieldInfo and ConstructorInfo constructs. Obviously being typed, can only be used when the type is known, but there were still substantial places across the code base; I think I got them all.
