### PR TITLE
Unsafe write encoded string 3

### DIFF
--- a/Jil/Serialize/Methods.cs
+++ b/Jil/Serialize/Methods.cs
@@ -357,6 +357,242 @@ namespace Jil.Serialize
             writer.Write(buffer, 0, fracEnd + 2);
         }
 
+        private static int WriteHexQuads(char c, int i, char[] buffer)
+        {
+            var b = buffer;
+            // This is converted into an IL switch, so don't fret about lookup times
+            switch (c)
+            {
+                case '\u0000': b[++i] = '\\'; b[++i] = 'u'; b[++i] = '0'; b[++i] = '0'; b[++i] = '0'; b[++i] = '0'; break;
+                case '\u0001': b[++i] = '\\'; b[++i] = 'u'; b[++i] = '0'; b[++i] = '0'; b[++i] = '0'; b[++i] = '1'; break;
+                case '\u0002': b[++i] = '\\'; b[++i] = 'u'; b[++i] = '0'; b[++i] = '0'; b[++i] = '0'; b[++i] = '2'; break;
+                case '\u0003': b[++i] = '\\'; b[++i] = 'u'; b[++i] = '0'; b[++i] = '0'; b[++i] = '0'; b[++i] = '3'; break;
+                case '\u0004': b[++i] = '\\'; b[++i] = 'u'; b[++i] = '0'; b[++i] = '0'; b[++i] = '0'; b[++i] = '4'; break;
+                case '\u0005': b[++i] = '\\'; b[++i] = 'u'; b[++i] = '0'; b[++i] = '0'; b[++i] = '0'; b[++i] = '5'; break;
+                case '\u0006': b[++i] = '\\'; b[++i] = 'u'; b[++i] = '0'; b[++i] = '0'; b[++i] = '0'; b[++i] = '6'; break;
+                case '\u0007': b[++i] = '\\'; b[++i] = 'u'; b[++i] = '0'; b[++i] = '0'; b[++i] = '0'; b[++i] = '7'; break;
+                case '\u0008': b[++i] = '\\'; b[++i] = 'b'; break;
+                case '\u0009': b[++i] = '\\'; b[++i] = 't'; break;
+                case '\u000A': b[++i] = '\\'; b[++i] = 'n'; break;
+                case '\u000B': b[++i] = '\\'; b[++i] = 'u'; b[++i] = '0'; b[++i] = '0'; b[++i] = '0'; b[++i] = 'B'; break;
+                case '\u000C': b[++i] = '\\'; b[++i] = 'f'; break;
+                case '\u000D': b[++i] = '\\'; b[++i] = 'r'; break;
+                case '\u000E': b[++i] = '\\'; b[++i] = 'u'; b[++i] = '0'; b[++i] = '0'; b[++i] = '0'; b[++i] = 'E'; break;
+                case '\u000F': b[++i] = '\\'; b[++i] = 'u'; b[++i] = '0'; b[++i] = '0'; b[++i] = '0'; b[++i] = 'F'; break;
+                case '\u0010': b[++i] = '\\'; b[++i] = 'u'; b[++i] = '0'; b[++i] = '0'; b[++i] = '1'; b[++i] = '0'; break;
+                case '\u0011': b[++i] = '\\'; b[++i] = 'u'; b[++i] = '0'; b[++i] = '0'; b[++i] = '1'; b[++i] = '1'; break;
+                case '\u0012': b[++i] = '\\'; b[++i] = 'u'; b[++i] = '0'; b[++i] = '0'; b[++i] = '1'; b[++i] = '2'; break;
+                case '\u0013': b[++i] = '\\'; b[++i] = 'u'; b[++i] = '0'; b[++i] = '0'; b[++i] = '1'; b[++i] = '3'; break;
+                case '\u0014': b[++i] = '\\'; b[++i] = 'u'; b[++i] = '0'; b[++i] = '0'; b[++i] = '1'; b[++i] = '4'; break;
+                case '\u0015': b[++i] = '\\'; b[++i] = 'u'; b[++i] = '0'; b[++i] = '0'; b[++i] = '1'; b[++i] = '5'; break;
+                case '\u0016': b[++i] = '\\'; b[++i] = 'u'; b[++i] = '0'; b[++i] = '0'; b[++i] = '1'; b[++i] = '6'; break;
+                case '\u0017': b[++i] = '\\'; b[++i] = 'u'; b[++i] = '0'; b[++i] = '0'; b[++i] = '1'; b[++i] = '7'; break;
+                case '\u0018': b[++i] = '\\'; b[++i] = 'u'; b[++i] = '0'; b[++i] = '0'; b[++i] = '1'; b[++i] = '8'; break;
+                case '\u0019': b[++i] = '\\'; b[++i] = 'u'; b[++i] = '0'; b[++i] = '0'; b[++i] = '1'; b[++i] = '9'; break;
+                case '\u001A': b[++i] = '\\'; b[++i] = 'u'; b[++i] = '0'; b[++i] = '0'; b[++i] = '1'; b[++i] = 'A'; break;
+                case '\u001B': b[++i] = '\\'; b[++i] = 'u'; b[++i] = '0'; b[++i] = '0'; b[++i] = '1'; b[++i] = 'B'; break;
+                case '\u001C': b[++i] = '\\'; b[++i] = 'u'; b[++i] = '0'; b[++i] = '0'; b[++i] = '1'; b[++i] = 'B'; break;
+                case '\u001D': b[++i] = '\\'; b[++i] = 'u'; b[++i] = '0'; b[++i] = '0'; b[++i] = '1'; b[++i] = 'D'; break;
+                case '\u001E': b[++i] = '\\'; b[++i] = 'u'; b[++i] = '0'; b[++i] = '0'; b[++i] = '1'; b[++i] = 'E'; break;
+                case '\u001F': b[++i] = '\\'; b[++i] = 'u'; b[++i] = '0'; b[++i] = '0'; b[++i] = '1'; b[++i] = 'F'; break;
+                default: throw new ApplicationException();
+            }
+
+            return i;
+        }
+
+        private unsafe static int WriteEncodedStringWithInitializedBuffer(TextWriter writer, string strRef, int i, char[] buffer)
+        {
+            var b = buffer;
+
+            fixed (char* strFixed = strRef)
+            {
+                var checkLength = b.Length - 10;
+                for (var j = 0; j < strRef.Length; ++j)
+                {
+                    if (strFixed[j] > '\u001F')
+                    {
+                        switch (strFixed[j])
+                        {
+                            case '\\': b[++i] = '\\'; b[++i] = '\\'; break;
+                            case '"': b[++i] = '\\'; b[++i] = '"'; break;
+                            default: b[++i] = strFixed[j]; break;
+                        }
+                    }
+                    else
+                    {
+                        i = WriteHexQuads(strFixed[j], i, b);
+                    }
+
+                    if (i > checkLength)
+                    {
+                        writer.Write(b, 0, i+1);
+                        i = -1;
+                    }
+                }
+            }
+
+            return i;
+        }
+
+        private unsafe static int WriteEncodedStringWithInitializedBufferJSONP(TextWriter writer, string strRef, int i, char[] buffer)
+        {
+            var b = buffer;
+
+            fixed (char* strFixed = strRef)
+            {
+                var checkLength = b.Length - 10;
+                for (var j = 0; j < strRef.Length; ++j)
+                {
+                    if (strFixed[j] > '\u001F')
+                    {
+                        switch (strFixed[j])
+                        {
+                            case '\\': b[++i] = '\\'; b[++i] = '\\'; break;
+                            case '"': b[++i] = '\\'; b[++i] = '"'; break;
+                            case '\u2028': b[++i] = '\\'; b[++i] = 'u'; b[++i] = '2'; b[++i] = '0'; b[++i] = '2'; b[++i] = '8'; break;
+                            case '\u2029': b[++i] = '\\'; b[++i] = 'u'; b[++i] = '2'; b[++i] = '0'; b[++i] = '2'; b[++i] = '9'; break;
+                            default: b[++i] = strFixed[j]; break;
+                        }
+                    }
+                    else
+                    {
+                        i = WriteHexQuads(strFixed[j], i, b);
+                    }
+
+                    if (i > checkLength)
+                    {
+                        writer.Write(b, 0, i+1);
+                        i = -1;
+                    }
+                }
+            }
+
+            return i;
+        }
+
+        private static void WriteEncodedString(TextWriter writer, string strRef, char[] buffer)
+        {
+            var i = WriteEncodedStringWithInitializedBuffer(writer, strRef, -1, buffer);
+
+            writer.Write(buffer, 0, i + 1);
+        }
+
+        private static void WriteEncodedStringJSONP(TextWriter writer, string strRef, char[] buffer)
+        {
+            var i = WriteEncodedStringWithInitializedBufferJSONP(writer, strRef, -1, buffer);
+
+            writer.Write(buffer, 0, i + 1);
+        }
+
+        private static void WriteEncodedStringWithQuotes(TextWriter writer, string strRef, char[] buffer)
+        {
+            var i = -1;
+            buffer[++i] = '\"';
+            i = WriteEncodedStringWithInitializedBuffer(writer, strRef, i, buffer);
+            buffer[++i] = '\"';
+
+            writer.Write(buffer, 0, i + 1);
+        }
+
+        private static void WriteEncodedStringWithQuotesJSONP(TextWriter writer, string strRef, char[] buffer)
+        {
+            var i = -1;
+            buffer[++i] = '\"';
+            i = WriteEncodedStringWithInitializedBufferJSONP(writer, strRef, i, buffer);
+            buffer[++i] = '\"';
+
+            writer.Write(buffer, 0, i + 1);
+        }
+
+        internal static readonly MethodInfo WriteEncodedStringWithQuotesWithoutNullsInlineBuffered = typeof(Methods).GetMethod("_WriteEncodedStringWithQuotesWithoutNullsInlineBuffered", BindingFlags.NonPublic | BindingFlags.Static);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static void _WriteEncodedStringWithQuotesWithoutNullsInlineBuffered(TextWriter writer, string strRef, char[] buffer)
+        {
+            if (strRef == null) return;
+
+            WriteEncodedStringWithQuotes(writer, strRef, buffer);
+        }
+
+        internal static readonly MethodInfo WriteEncodedStringWithQuotesWithoutNullsInlineJSONPBuffered = typeof(Methods).GetMethod("_WriteEncodedStringWithQuotesWithoutNullsInlineJSONPBuffered", BindingFlags.NonPublic | BindingFlags.Static);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static void _WriteEncodedStringWithQuotesWithoutNullsInlineJSONPBuffered(TextWriter writer, string strRef, char[] buffer)
+        {
+            if (strRef == null) return;
+
+            WriteEncodedStringWithQuotesJSONP(writer, strRef, buffer);
+        }
+
+        internal static readonly MethodInfo WriteEncodedStringWithQuotesWithNullsInlineBuffered = typeof(Methods).GetMethod("_WriteEncodedStringWithQuotesWithNullsInlineBuffered", BindingFlags.NonPublic | BindingFlags.Static);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static void _WriteEncodedStringWithQuotesWithNullsInlineBuffered(TextWriter writer, string strRef, char[] buffer)
+        {
+            if (strRef == null)
+            {
+                writer.Write("null");
+                return;
+            }
+
+            WriteEncodedStringWithQuotes(writer, strRef, buffer);
+        }
+
+        internal static readonly MethodInfo WriteEncodedStringWithQuotesWithNullsInlineJSONPBuffered = typeof(Methods).GetMethod("_WriteEncodedStringWithQuotesWithNullsInlineJSONPBuffered", BindingFlags.NonPublic | BindingFlags.Static);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static void _WriteEncodedStringWithQuotesWithNullsInlineJSONPBuffered(TextWriter writer, string strRef, char[] buffer)
+        {
+            if (strRef == null)
+            {
+                writer.Write("null");
+                return;
+            }
+
+            WriteEncodedStringWithQuotesJSONP(writer, strRef, buffer);
+        }
+
+        internal static readonly MethodInfo WriteEncodedStringWithoutNullsInlineBuffered = typeof(Methods).GetMethod("_WriteEncodedStringWithoutNullsInlineBuffered", BindingFlags.NonPublic | BindingFlags.Static);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static void _WriteEncodedStringWithoutNullsInlineBuffered(TextWriter writer, string strRef, char[] buffer)
+        {
+            if (strRef == null) return;
+
+            WriteEncodedString(writer, strRef, buffer);
+        }
+
+        internal static readonly MethodInfo WriteEncodedStringWithoutNullsInlineJSONPBuffered = typeof(Methods).GetMethod("_WriteEncodedStringWithoutNullsInlineJSONPBuffered", BindingFlags.NonPublic | BindingFlags.Static);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static void _WriteEncodedStringWithoutNullsInlineJSONPBuffered(TextWriter writer, string strRef, char[] buffer)
+        {
+            if (strRef == null) return;
+
+            WriteEncodedStringJSONP(writer, strRef, buffer);
+        }
+
+        internal static readonly MethodInfo WriteEncodedStringWithNullsInlineJSONPBuffered = typeof(Methods).GetMethod("_WriteEncodedStringWithNullsInlineJSONPBuffered", BindingFlags.NonPublic | BindingFlags.Static);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static void _WriteEncodedStringWithNullsInlineJSONPBuffered(TextWriter writer, string strRef, char[] buffer)
+        {
+            if (strRef == null)
+            {
+                writer.Write("null");
+                return;
+            }
+
+            WriteEncodedStringJSONP(writer, strRef, buffer);
+        }
+
+        internal static readonly MethodInfo WriteEncodedStringWithNullsInlineBuffered = typeof(Methods).GetMethod("_WriteEncodedStringWithNullsInlineBuffered", BindingFlags.NonPublic | BindingFlags.Static);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static void _WriteEncodedStringWithNullsInlineBuffered(TextWriter writer, string strRef, char[] buffer)
+        {
+            if (strRef == null)
+            {
+                writer.Write("null");
+                return;
+            }
+
+            WriteEncodedString(writer, strRef, buffer);
+        }
+
         internal static readonly MethodInfo WriteEncodedStringWithQuotesWithoutNullsInlineUnsafe = typeof(Methods).GetMethod("_WriteEncodedStringWithQuotesWithoutNullsInlineUnsafe", BindingFlags.NonPublic | BindingFlags.Static);
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static unsafe void _WriteEncodedStringWithQuotesWithoutNullsInlineUnsafe(TextWriter writer, string strRef)

--- a/JilTests/SpeedProofTests.cs
+++ b/JilTests/SpeedProofTests.cs
@@ -1233,6 +1233,110 @@ namespace JilTests
             Assert.IsTrue(automataTime < dictionaryTime, "automataTime = " + automataTime + ", dictionaryTime = " + dictionaryTime);
         }
 
+        class _NewWriteEncodedString
+        {
+            public string Foo { get; set; }
+        }
+
+        [TestMethod]
+        public void NewWriteEncodedStringMultiple()
+        {
+            Action<TextWriter, List<_NewWriteEncodedString>, int> newVersion;
+            Action<TextWriter, List<_NewWriteEncodedString>, int> oldVersion;
+
+            try
+            {
+                {
+                    InlineSerializer<List<_NewWriteEncodedString>>.UseBufferedStringWriting = true;
+                    Exception ignored;
+
+                    // Build the *actual* serializer method
+                    newVersion = InlineSerializerHelper.Build<List<_NewWriteEncodedString>>(typeof(Jil.Serialize.NewtonsoftStyleExcludeNullsJSONPTypeCache<>), pretty: false, excludeNulls: true, jsonp: true, dateFormat: DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch, includeInherited: false, exceptionDuringBuild: out ignored);
+                }
+
+                {
+                    InlineSerializer<List<_NewWriteEncodedString>>.UseBufferedStringWriting = false;
+                    Exception ignored;
+
+                    // Build the *actual* serializer method
+                    oldVersion = InlineSerializerHelper.Build<List<_NewWriteEncodedString>>(typeof(Jil.Serialize.NewtonsoftStyleExcludeNullsJSONPTypeCache<>), pretty: false, excludeNulls: true, jsonp: true, dateFormat: DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch, includeInherited: false, exceptionDuringBuild: out ignored);
+                }
+            }
+            finally
+            {
+                InlineSerializer<List<_NewWriteEncodedString>>.UseBufferedStringWriting = true;
+            }
+
+            var rand = new Random(163983052);
+
+            var toSerialize = new List<_NewWriteEncodedString>();
+            for (var i = 0; i < 100000; i++)
+            {
+                toSerialize.Add(
+                    new _NewWriteEncodedString
+                    {
+                        Foo = _RandString(rand)
+                    }
+                );
+            }
+
+            toSerialize = toSerialize.Select(_ => new { _ = _, Order = rand.Next() }).OrderBy(o => o.Order).Select(o => o._).Where((o, ix) => ix % 2 == 0).ToList();
+
+            double newTime, oldTime;
+            CompareTimes(new [] {toSerialize}.ToList(), newVersion, oldVersion, out newTime, out oldTime);
+
+            Assert.IsTrue(newTime < oldTime, "newTime = " + newTime + ", oldTime = " + oldTime);
+        }
+
+        [TestMethod]
+        public void NewWriteEncodedStringSingle()
+        {
+            Action<TextWriter, _NewWriteEncodedString, int> newVersion;
+            Action<TextWriter, _NewWriteEncodedString, int> oldVersion;
+
+            try
+            {
+                {
+                    InlineSerializer<_NewWriteEncodedString>.UseBufferedStringWriting = true;
+                    Exception ignored;
+
+                    // Build the *actual* serializer method
+                    newVersion = InlineSerializerHelper.Build<_NewWriteEncodedString>(typeof(Jil.Serialize.NewtonsoftStyleExcludeNullsJSONPTypeCache<>), pretty: false, excludeNulls: true, jsonp: true, dateFormat: DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch, includeInherited: false, exceptionDuringBuild: out ignored);
+                }
+
+                {
+                    InlineSerializer<List<_NewWriteEncodedString>>.UseBufferedStringWriting = false;
+                    Exception ignored;
+
+                    // Build the *actual* serializer method
+                    oldVersion = InlineSerializerHelper.Build<_NewWriteEncodedString>(typeof(Jil.Serialize.NewtonsoftStyleExcludeNullsJSONPTypeCache<>), pretty: false, excludeNulls: true, jsonp: true, dateFormat: DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch, includeInherited: false, exceptionDuringBuild: out ignored);
+                }
+            }
+            finally
+            {
+                InlineSerializer<_NewWriteEncodedString>.UseBufferedStringWriting = true;
+            }
+
+            var rand = new Random(163983052);
+
+            var toSerialize = new List<_NewWriteEncodedString>();
+            for (var i = 0; i < 100000; i++)
+            {
+                toSerialize.Add(
+                    new _NewWriteEncodedString
+                    {
+                        Foo = _RandString(rand)
+                    }
+                );
+            }
+
+            toSerialize = toSerialize.Select(_ => new { _ = _, Order = rand.Next() }).OrderBy(o => o.Order).Select(o => o._).Where((o, ix) => ix % 2 == 0).ToList();
+
+            double newTime, oldTime;
+            CompareTimes(toSerialize, newVersion, oldVersion, out newTime, out oldTime);
+
+            Assert.IsTrue(newTime < oldTime, "newTime = " + newTime + ", oldTime = " + oldTime);
+        }
 #endif
     }
 }


### PR DESCRIPTION
Another attempt at getting WriteEncodedString* across the line. This one is using the existing CharBuffer, and has removed the expanding component; so we shouldn't have any of the concerns that we have with the deserializer. I have included your original speed test (which does 'fail' sometimes, marginally), as well as the speed test with the list of objects. I have also made the code fully switchable with UseBufferedStringWriting flag.

Personally I think the buffer should be larger, but I'm trying to do the bare minimum to fit this in.

Existing master

	Serializing
	===========
	Single:
	Type    Jil Static MS   Jil Static      Jil Dynamic MS  Jil Dynamic
	User    0.0205          0.0205
	Answer  0.0861          0.0861
	Question        0.52535         0.5198

	Lists:
	Type    Jil Static MS   Jil Static      Jil Dynamic MS  Jil Dynamic
	User    0.1035          0.103
	Answer  0.3181          0.3194
	Question        1.7821          1.7672

	Dictionaries of strings to:
	Type    Jil Static MS   Jil Static      Jil Dynamic MS  Jil Dynamic
	User    0.6072          0.609
	Answer  2.10115         2.1344
	Question        7.7844          7.77235

Using the 36-byte buffer

	Serializing
	===========
	Single:
	Type    Jil Static MS   Jil Static      Jil Dynamic MS  Jil Dynamic
	User    0.0169          0.0165
	Answer  0.0548          0.0557
	Question        0.3632          0.36025

	Lists:
	Type    Jil Static MS   Jil Static      Jil Dynamic MS  Jil Dynamic
	User    0.0731          0.0731
	Answer  0.2146          0.2146
	Question        1.2257          1.22415

	Dictionaries of strings to:
	Type    Jil Static MS   Jil Static      Jil Dynamic MS  Jil Dynamic
	User    0.4252          0.4272
	Answer  1.49945         1.4903
	Question        5.755           5.6945

Doubleing the buffer to 72-byte-buffer

	Serializing
	===========
	Single:
	Type    Jil Static MS   Jil Static      Jil Dynamic MS  Jil Dynamic
	User    0.0133          0.0133
	Answer  0.0481          0.0481
	Question        0.3279          0.327

	Lists:
	Type    Jil Static MS   Jil Static      Jil Dynamic MS  Jil Dynamic
	User    0.0678          0.0682
	Answer  0.1949          0.1936
	Question        1.1039          1.10725

	Dictionaries of strings to:
	Type    Jil Static MS   Jil Static      Jil Dynamic MS  Jil Dynamic
	User    0.4007          0.3948
	Answer  1.3966          1.3944
	Question        5.5145          5.53215

Obviously this is a replacement for the other pull request if this one is accepted.