### PR TITLE
Fix deep object graph deserialization (#71)

### DIFF
--- a/Jil/Deserialize/SetterLookup.cs
+++ b/Jil/Deserialize/SetterLookup.cs
@@ -34,7 +34,7 @@ namespace Jil.Deserialize
         private static IReadOnlyList<Tuple<string, MemberInfo>> GetOrderedSetters()
         {
             var forType = typeof(ForType);
-            var flags = BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public;
+            var flags = BindingFlags.Instance | BindingFlags.Public;
 
             var fields = forType.GetFields(flags).Where(field => field.ShouldUseMember());
             var props = forType.GetProperties(flags).Where(p => p.SetMethod != null && p.ShouldUseMember());

--- a/JilTests/DeepObjectGraphTest.cs
+++ b/JilTests/DeepObjectGraphTest.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using Jil;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace JilDeepGraphTest
+{
+    [TestClass]
+    public class DeepObjectGraphTests
+    {
+        [TestMethod]
+        public void DeepObjectGraphShouldNotBeEmpty()
+        {
+            // given
+            var model = new UserCredentialsUpdateResponse()
+            {
+                User =
+                    new UserDto()
+                    {
+                        DateOfBirth = new DateTime(1980, 01, 01),
+                        CreatedAtUtc = new DateTime(2014, 01, 01, 08, 00, 00),
+                        UserId = 1,
+                        Username = "SomeUsername"
+                    }
+            };
+
+            //When
+            var stringBuilder = new StringBuilder();
+            using (var stringOutput = new StringWriter(stringBuilder))
+            {
+                JSON.Serialize(model, stringOutput, Options.IncludeInherited);
+            }
+            var serializedJsonAsString = stringBuilder.ToString();
+
+            // round tripping
+            var deserializedRoundtrippedObject = JSON.Deserialize(serializedJsonAsString, typeof(UserCredentialsUpdateResponse), Options.IncludeInherited);
+            var deserializedRoundtrippedInstance = deserializedRoundtrippedObject as UserCredentialsUpdateResponse;
+
+            // Then
+            Assert.AreNotEqual("{}", serializedJsonAsString);
+            Assert.IsNotNull(deserializedRoundtrippedInstance);
+            Assert.IsInstanceOfType(deserializedRoundtrippedInstance, typeof(UserCredentialsUpdateResponse));
+
+            Assert.IsNotNull(deserializedRoundtrippedInstance.User); // << this fails
+
+            Assert.AreEqual(deserializedRoundtrippedInstance.User.CreatedAtUtc.ToUniversalTime(), model.User.CreatedAtUtc.ToUniversalTime());
+            Assert.AreEqual(deserializedRoundtrippedInstance.User.DateOfBirth.ToUniversalTime(), model.User.DateOfBirth.ToUniversalTime());
+            Assert.AreEqual(deserializedRoundtrippedInstance.User.UserId, model.User.UserId);
+            Assert.AreEqual(deserializedRoundtrippedInstance.User.Username, model.User.Username);
+        }
+    }
+
+    public class UserCredentialsUpdateResponse : UserResponse
+    {
+        public UserCredentialsUpdateResponse()
+        {
+        }
+    }
+
+    public class UserResponse : Response
+    {
+        public UserResponse()
+        {
+
+        }
+
+        public UserDto User { get; set; }
+    }
+
+    public class UserDto : CreatedAtDto
+    {
+        public UserDto()
+        {
+        }
+
+        public DateTime DateOfBirth { get; set; }
+
+        public long UserId { get; set; }
+
+        public string Username { get; set; }
+    }
+
+    #region Base Classes
+    public abstract class CreatedAtDto
+    {
+        public virtual DateTime CreatedAtUtc { get; set; }
+    }
+
+    public abstract class Response
+    {
+
+    }
+    #endregion Base Classes
+}

--- a/JilTests/JilTests.csproj
+++ b/JilTests/JilTests.csproj
@@ -101,6 +101,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="DeepObjectGraphTest.cs" />
     <Compile Include="DeserializeDynamicTests.cs" />
     <Compile Include="DeserializeTests.cs" />
     <Compile Include="DynamicSerializationTests.cs" />


### PR DESCRIPTION
Removed BindingFlags.DeclaredOnly to find fields/properties. I don't see the need to make this an option, because if the fields exist in both the json and the object then they will be deserilized; otherwise they won't.
