### PR TITLE
Consolidated deserializer type cache

### DIFF
--- a/Jil/Deserialize/InlineDeserializer.cs
+++ b/Jil/Deserialize/InlineDeserializer.cs
@@ -20,7 +20,7 @@ namespace Jil.Deserialize
         const string CharBufferName = "char_buffer";
         const string StringBuilderName = "string_builder";
         
-        readonly Type RecursionLookupType;
+        readonly Type OptionsType;
         readonly DateTimeFormat DateFormat;
 
         bool UsingCharBuffer;
@@ -28,9 +28,9 @@ namespace Jil.Deserialize
 
         Emit Emit;
 
-        public InlineDeserializer(Type recursionLookupType, DateTimeFormat dateFormat)
+        public InlineDeserializer(Type optionsType, DateTimeFormat dateFormat)
         {
-            RecursionLookupType = recursionLookupType;
+            OptionsType = optionsType;
             DateFormat = dateFormat;
         }
 
@@ -976,7 +976,7 @@ namespace Jil.Deserialize
 
         void LoadRecursiveTypeDelegate(Type recursiveType)
         {
-            var typeCache = RecursionLookupType.MakeGenericType(recursiveType);
+            var typeCache = typeof(TypeCache<,>).MakeGenericType(OptionsType, recursiveType);
             var thunk = typeCache.GetField("Thunk", BindingFlags.Public | BindingFlags.Static);
             Emit.LoadField(thunk);
         }
@@ -1802,7 +1802,7 @@ namespace Jil.Deserialize
             var ret = forType.FindRecursiveOrReusedTypes();
             foreach (var primeType in ret)
             {
-                var loadMtd = this.RecursionLookupType.MakeGenericType(primeType).GetMethod("Load", BindingFlags.Public | BindingFlags.Static);
+                var loadMtd = typeof(TypeCache<,>).MakeGenericType(OptionsType, primeType).GetMethod("Load", BindingFlags.Public | BindingFlags.Static);
                 loadMtd.Invoke(null, new object[0]);
             }
 
@@ -1837,9 +1837,9 @@ namespace Jil.Deserialize
 
     static class InlineDeserializerHelper
     {
-        static Func<TextReader, int, ReturnType> BuildAlwaysFailsWith<ReturnType>(Type typeCacheType)
+        static Func<TextReader, int, ReturnType> BuildAlwaysFailsWith<ReturnType>(Type optionsType)
         {
-            var specificTypeCache = typeCacheType.MakeGenericType(typeof(ReturnType));
+            var specificTypeCache = typeof(TypeCache<,>).MakeGenericType(optionsType, typeof(ReturnType));
             var stashField = specificTypeCache.GetField("ExceptionDuringBuild", BindingFlags.Static | BindingFlags.Public);
 
             var emit = Emit.NewDynamicMethod(typeof(ReturnType), new[] { typeof(TextReader), typeof(int) });
@@ -1851,9 +1851,9 @@ namespace Jil.Deserialize
             return emit.CreateDelegate<Func<TextReader, int, ReturnType>>(Utils.DelegateOptimizationOptions);
         }
 
-        public static Func<TextReader, int, ReturnType> Build<ReturnType>(Type typeCacheType, DateTimeFormat dateFormat, out Exception exceptionDuringBuild)
+        public static Func<TextReader, int, ReturnType> Build<ReturnType>(Type optionsType, DateTimeFormat dateFormat, out Exception exceptionDuringBuild)
         {
-            var obj = new InlineDeserializer<ReturnType>(typeCacheType, dateFormat);
+            var obj = new InlineDeserializer<ReturnType>(optionsType, dateFormat);
 
             Func<TextReader, int, ReturnType> ret;
             try
@@ -1864,7 +1864,7 @@ namespace Jil.Deserialize
             catch (ConstructionException e)
             {
                 exceptionDuringBuild = e;
-                ret = BuildAlwaysFailsWith<ReturnType>(typeCacheType);
+                ret = BuildAlwaysFailsWith<ReturnType>(optionsType);
             }
 
             return ret;

--- a/Jil/Deserialize/TypeCaches.cs
+++ b/Jil/Deserialize/TypeCaches.cs
@@ -7,7 +7,13 @@ using System.Threading.Tasks;
 
 namespace Jil.Deserialize
 {
-    static class NewtonsoftStyleTypeCache<T>
+    interface IDeserializeOptions
+    {
+        DateTimeFormat DateFormat { get; }
+    }
+
+    static class TypeCache<TOptions, T>
+        where TOptions : IDeserializeOptions, new()
     {
         static readonly object InitLock = new object();
         static volatile bool BeingBuilt = false;
@@ -30,92 +36,30 @@ namespace Jil.Deserialize
                 if (Thunk != null || BeingBuilt) return;
                 BeingBuilt = true;
 
-                Thunk = InlineDeserializerHelper.Build<T>(typeof(NewtonsoftStyleTypeCache<>), DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch, exceptionDuringBuild: out ExceptionDuringBuild);
+                var options = new TOptions();
+
+                Thunk = InlineDeserializerHelper.Build<T>(typeof(TOptions), options.DateFormat, exceptionDuringBuild: out ExceptionDuringBuild);
             }
         }
     }
 
-    static class MillisecondStyleTypeCache<T>
+    class NewtonsoftStyle : IDeserializeOptions
     {
-        static readonly object InitLock = new object();
-        static volatile bool BeingBuilt = false;
-
-        public static volatile Func<TextReader, int, T> Thunk;
-        public static Exception ExceptionDuringBuild;
-
-        public static Func<TextReader, int, T> Get()
-        {
-            Load();
-            return Thunk;
-        }
-
-        public static void Load()
-        {
-            if (Thunk != null) return;
-
-            lock (InitLock)
-            {
-                if (Thunk != null || BeingBuilt) return;
-                BeingBuilt = true;
-
-                Thunk = InlineDeserializerHelper.Build<T>(typeof(MillisecondStyleTypeCache<>), DateTimeFormat.MillisecondsSinceUnixEpoch, exceptionDuringBuild: out ExceptionDuringBuild);
-            }
-        }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
     }
 
-    static class SecondStyleTypeCache<T>
+    class MillisecondStyle : IDeserializeOptions
     {
-        static readonly object InitLock = new object();
-        static volatile bool BeingBuilt = false;
-
-        public static volatile Func<TextReader, int, T> Thunk;
-        public static Exception ExceptionDuringBuild;
-
-        public static Func<TextReader, int, T> Get()
-        {
-            Load();
-            return Thunk;
-        }
-
-        public static void Load()
-        {
-            if (Thunk != null) return;
-
-            lock (InitLock)
-            {
-                if (Thunk != null || BeingBuilt) return;
-                BeingBuilt = true;
-
-                Thunk = InlineDeserializerHelper.Build<T>(typeof(SecondStyleTypeCache<>), DateTimeFormat.SecondsSinceUnixEpoch, exceptionDuringBuild: out ExceptionDuringBuild);
-            }
-        }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
     }
 
-    static class ISO8601StyleTypeCache<T>
+    class SecondStyle : IDeserializeOptions
     {
-        static readonly object InitLock = new object();
-        static volatile bool BeingBuilt = false;
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
+    }
 
-        public static volatile Func<TextReader, int,  T> Thunk;
-        public static Exception ExceptionDuringBuild;
-
-        public static Func<TextReader, int, T> Get()
-        {
-            Load();
-            return Thunk;
-        }
-
-        public static void Load()
-        {
-            if (Thunk != null) return;
-
-            lock (InitLock)
-            {
-                if (Thunk != null || BeingBuilt) return;
-                BeingBuilt = true;
-
-                Thunk = InlineDeserializerHelper.Build<T>(typeof(ISO8601StyleTypeCache<>), DateTimeFormat.ISO8601, exceptionDuringBuild: out ExceptionDuringBuild);
-            }
-        }
+    class ISO8601Style : IDeserializeOptions
+    {
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
     }
 }

--- a/Jil/JSON.cs
+++ b/Jil/JSON.cs
@@ -576,13 +576,13 @@ namespace Jil
                 switch (options.UseDateTimeFormat)
                 {
                     case DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch:
-                        return Jil.Deserialize.NewtonsoftStyleTypeCache<T>.Get()(reader, 0);
+                        return Jil.Deserialize.TypeCache<Jil.Deserialize.NewtonsoftStyle, T>.Get()(reader, 0);
                     case DateTimeFormat.MillisecondsSinceUnixEpoch:
-                        return Jil.Deserialize.MillisecondStyleTypeCache<T>.Get()(reader, 0);
+                        return Jil.Deserialize.TypeCache<Jil.Deserialize.MillisecondStyle, T>.Get()(reader, 0);
                     case DateTimeFormat.SecondsSinceUnixEpoch:
-                        return Jil.Deserialize.SecondStyleTypeCache<T>.Get()(reader, 0);
+                        return Jil.Deserialize.TypeCache<Jil.Deserialize.SecondStyle, T>.Get()(reader, 0);
                     case DateTimeFormat.ISO8601:
-                        return Jil.Deserialize.ISO8601StyleTypeCache<T>.Get()(reader, 0);
+                        return Jil.Deserialize.TypeCache<Jil.Deserialize.ISO8601Style, T>.Get()(reader, 0);
                     default: throw new InvalidOperationException("Unexpected Options: " + options);
                 }
 

--- a/JilTests/SpeedProofTests.cs
+++ b/JilTests/SpeedProofTests.cs
@@ -967,7 +967,7 @@ namespace JilTests
                     Exception ignored;
 
                     // Build the *actual* deserializer method
-                    automata = InlineDeserializerHelper.Build<_UseNameAutomataWhenMatchingEnums>(typeof(Jil.Deserialize.NewtonsoftStyleTypeCache<_UseNameAutomataWhenMatchingEnums>), dateFormat: Jil.DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch, exceptionDuringBuild: out ignored);
+                    automata = InlineDeserializerHelper.Build<_UseNameAutomataWhenMatchingEnums>(typeof(Jil.Deserialize.TypeCache<NewtonsoftStyle, _UseNameAutomataWhenMatchingEnums>), dateFormat: Jil.DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch, exceptionDuringBuild: out ignored);
                 }
 
                 {
@@ -975,7 +975,7 @@ namespace JilTests
                     Exception ignored;
 
                     // Build the *actual* deserializer method
-                    method = InlineDeserializerHelper.Build<_UseNameAutomataWhenMatchingEnums>(typeof(Jil.Deserialize.NewtonsoftStyleTypeCache<_UseHashWhenMatchingMembers>), dateFormat: Jil.DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch, exceptionDuringBuild: out ignored);
+                    method = InlineDeserializerHelper.Build<_UseNameAutomataWhenMatchingEnums>(typeof(Jil.Deserialize.TypeCache<NewtonsoftStyle, _UseHashWhenMatchingMembers>), dateFormat: Jil.DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch, exceptionDuringBuild: out ignored);
                 }
             }
             finally
@@ -1085,7 +1085,7 @@ namespace JilTests
                     Exception ignored;
 
                     // Build the *actual* deserializer method
-                    automata = InlineDeserializerHelper.Build<_UseNameAutomata>(typeof(Jil.Deserialize.NewtonsoftStyleTypeCache<>), dateFormat: Jil.DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch, exceptionDuringBuild: out ignored);
+                    automata = InlineDeserializerHelper.Build<_UseNameAutomata>(typeof(Jil.Deserialize.NewtonsoftStyle), dateFormat: Jil.DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch, exceptionDuringBuild: out ignored);
                 }
 
                 {
@@ -1093,7 +1093,7 @@ namespace JilTests
                     Exception ignored;
 
                     // Build the *actual* deserializer method
-                    dictionary = InlineDeserializerHelper.Build<_UseNameAutomata>(typeof(Jil.Deserialize.NewtonsoftStyleTypeCache<>), dateFormat: Jil.DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch, exceptionDuringBuild: out ignored);
+                    dictionary = InlineDeserializerHelper.Build<_UseNameAutomata>(typeof(Jil.Deserialize.NewtonsoftStyle), dateFormat: Jil.DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch, exceptionDuringBuild: out ignored);
                 }
             }
             finally


### PR DESCRIPTION
This was from a previous bug fix branch, but you manually merged, and didn't grab this bit as it wasn't required for the fix. Anyway, just a style thing. Less duplication. Easier to maintain. Not that the deserializer side is particularly messy, but this same style could be replicated for the Serializer side, where it is messy. The deserializer side was done first as it was easier for a proof of concept.
