### PR TITLE
Option for disabling conversion of DateTime properties to UTC

### DIFF
--- a/Jil/Deserialize/InlineDeserializer.cs
+++ b/Jil/Deserialize/InlineDeserializer.cs
@@ -1874,7 +1874,7 @@ namespace Jil.Deserialize
             }
         }
 
-        static ConstructorInfo OptionsCons = typeof(Options).GetConstructor(new[] { typeof(bool), typeof(bool), typeof(bool), typeof(DateTimeFormat), typeof(bool) });
+        static ConstructorInfo OptionsCons = typeof(Options).GetConstructor(new[] { typeof(bool), typeof(bool), typeof(bool), typeof(DateTimeFormat), typeof(bool), typeof(bool) });
         static ConstructorInfo ObjectBuilderCons = typeof(Jil.DeserializeDynamic.ObjectBuilder).GetConstructor(new[] { typeof(Options) });
         void ReadDynamic()
         {
@@ -1886,6 +1886,7 @@ namespace Jil.Deserialize
                 Emit.LoadConstant(false);                                                   // TextReader bool bool bool
                 Emit.LoadConstant((byte)DateFormat);                                        // TextReader bool bool bool byte
                 Emit.LoadConstant(false);                                                   // TextReader bool bool bool byte bool
+                Emit.LoadConstant(false);                                                   // TextReader bool bool bool byte bool bool
                 Emit.NewObject(OptionsCons);                                                // TextReader Options
                 Emit.NewObject(ObjectBuilderCons);                                          // TextReader ObjectBuilder
                 Emit.StoreLocal(dyn);                                                       // TextReader

--- a/Jil/JSON.cs
+++ b/Jil/JSON.cs
@@ -175,9 +175,20 @@ namespace Jil
 
         static void NewtonsoftStyle<T>(T data, TextWriter output, Options options)
         {
+            if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.IsJSONP && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                TypeCache<NewtonsoftStylePrettyPrintExcludeNullsJSONPInheritedNotConvertToUtc, T>.Get()(output, data, 0);
+                return;
+            }
             if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.IsJSONP && options.ShouldIncludeInherited)
             {
                 TypeCache<NewtonsoftStylePrettyPrintExcludeNullsJSONPInherited, T>.Get()(output, data, 0);
+                return;
+            }
+
+            if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.IsJSONP && !options.ShouldConvertToUtc)
+            {
+                TypeCache<NewtonsoftStylePrettyPrintExcludeNullsJSONPNotConvertToUtc, T>.Get()(output, data, 0);
                 return;
             }
 
@@ -187,9 +198,21 @@ namespace Jil
                 return;
             }
 
+            if (options.ShouldExcludeNulls && options.IsJSONP && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                TypeCache<NewtonsoftStyleExcludeNullsJSONPInheritedNotConvertToUtc, T>.Get()(output, data, 0);
+                return;
+            }
+
             if (options.ShouldExcludeNulls && options.IsJSONP && options.ShouldIncludeInherited)
             {
                 TypeCache<NewtonsoftStyleExcludeNullsJSONPInherited, T>.Get()(output, data, 0);
+                return;
+            }
+
+            if (options.ShouldPrettyPrint && options.IsJSONP && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                TypeCache<NewtonsoftStylePrettyPrintJSONPInheritedNotConvertToUtc, T>.Get()(output, data, 0);
                 return;
             }
 
@@ -199,9 +222,21 @@ namespace Jil
                 return;
             }
 
+            if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                TypeCache<NewtonsoftStylePrettyPrintExcludeNullsInheritedNotConvertToUtc, T>.Get()(output, data, 0);
+                return;
+            }
+
             if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.ShouldIncludeInherited)
             {
                 TypeCache<NewtonsoftStylePrettyPrintExcludeNullsInherited, T>.Get()(output, data, 0);
+                return;
+            }
+
+            if (options.ShouldExcludeNulls && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                TypeCache<NewtonsoftStyleExcludeNullsInheritedNotConvertToUtc, T>.Get()(output, data, 0);
                 return;
             }
 
@@ -211,9 +246,21 @@ namespace Jil
                 return;
             }
 
+            if (options.ShouldExcludeNulls && options.IsJSONP && !options.ShouldConvertToUtc)
+            {
+                TypeCache<NewtonsoftStyleExcludeNullsJSONPNotConvertToUtc, T>.Get()(output, data, 0);
+                return;
+            }
+
             if (options.ShouldExcludeNulls && options.IsJSONP)
             {
                 TypeCache<NewtonsoftStyleExcludeNullsJSONP, T>.Get()(output, data, 0);
+                return;
+            }
+
+            if (options.ShouldPrettyPrint && options.IsJSONP && !options.ShouldConvertToUtc)
+            {
+                TypeCache<NewtonsoftStylePrettyPrintJSONPNotConvertToUtc, T>.Get()(output, data, 0);
                 return;
             }
 
@@ -223,9 +270,21 @@ namespace Jil
                 return;
             }
 
+            if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && !options.ShouldConvertToUtc)
+            {
+                TypeCache<NewtonsoftStylePrettyPrintExcludeNullsNotConvertToUtc, T>.Get()(output, data, 0);
+                return;
+            }
+
             if (options.ShouldExcludeNulls && options.ShouldPrettyPrint)
             {
                 TypeCache<NewtonsoftStylePrettyPrintExcludeNulls, T>.Get()(output, data, 0);
+                return;
+            }
+
+            if (options.ShouldPrettyPrint && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                TypeCache<NewtonsoftStylePrettyPrintInheritedNotConvertToUtc, T>.Get()(output, data, 0);
                 return;
             }
 
@@ -235,9 +294,21 @@ namespace Jil
                 return;
             }
 
+            if (options.IsJSONP && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                TypeCache<NewtonsoftStyleJSONPInheritedNotConvertToUtc, T>.Get()(output, data, 0);
+                return;
+            }
+
             if (options.IsJSONP && options.ShouldIncludeInherited)
             {
                 TypeCache<NewtonsoftStyleJSONPInherited, T>.Get()(output, data, 0);
+                return;
+            }
+
+            if (options.ShouldExcludeNulls && !options.ShouldConvertToUtc)
+            {
+                TypeCache<NewtonsoftStyleExcludeNullsNotConvertToUtc, T>.Get()(output, data, 0);
                 return;
             }
 
@@ -247,9 +318,21 @@ namespace Jil
                 return;
             }
 
+            if (options.ShouldPrettyPrint && !options.ShouldConvertToUtc)
+            {
+                TypeCache<NewtonsoftStylePrettyPrintNotConvertToUtc, T>.Get()(output, data, 0);
+                return;
+            }
+
             if (options.ShouldPrettyPrint)
             {
                 TypeCache<NewtonsoftStylePrettyPrint, T>.Get()(output, data, 0);
+                return;
+            }
+
+            if (options.IsJSONP && !options.ShouldConvertToUtc)
+            {
+                TypeCache<NewtonsoftStyleJSONPNotConvertToUtc, T>.Get()(output, data, 0);
                 return;
             }
 
@@ -259,9 +342,21 @@ namespace Jil
                 return;
             }
 
+            if (options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                TypeCache<NewtonsoftStyleInheritedNotConvertToUtc, T>.Get()(output, data, 0);
+                return;
+            }
+
             if (options.ShouldIncludeInherited)
             {
                 TypeCache<NewtonsoftStyleInherited, T>.Get()(output, data, 0);
+                return;
+            }
+
+            if (!options.ShouldConvertToUtc)
+            {
+                TypeCache<NewtonsoftStyleNotConvertToUtc, T>.Get()(output, data, 0);
                 return;
             }
 
@@ -270,9 +365,19 @@ namespace Jil
 
         static string NewtonsoftStyleToString<T>(T data, Options options)
         {
+            if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.IsJSONP && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<NewtonsoftStylePrettyPrintExcludeNullsJSONPInheritedNotConvertToUtc, T>.GetToString(), data);
+            }
+
             if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.IsJSONP && options.ShouldIncludeInherited)
             {
                 return WriteToString(TypeCache<NewtonsoftStylePrettyPrintExcludeNullsJSONPInherited, T>.GetToString(), data);
+            }
+
+            if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.IsJSONP && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<NewtonsoftStylePrettyPrintExcludeNullsJSONPNotConvertToUtc, T>.GetToString(), data);
             }
 
             if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.IsJSONP)
@@ -280,9 +385,19 @@ namespace Jil
                 return WriteToString(TypeCache<NewtonsoftStylePrettyPrintExcludeNullsJSONP, T>.GetToString(), data);
             }
 
+            if (options.ShouldExcludeNulls && options.IsJSONP && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<NewtonsoftStyleExcludeNullsJSONPInheritedNotConvertToUtc, T>.GetToString(), data);
+            }
+
             if (options.ShouldExcludeNulls && options.IsJSONP && options.ShouldIncludeInherited)
             {
                 return WriteToString(TypeCache<NewtonsoftStyleExcludeNullsJSONPInherited, T>.GetToString(), data);
+            }
+
+            if (options.ShouldPrettyPrint && options.IsJSONP && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<NewtonsoftStylePrettyPrintJSONPInheritedNotConvertToUtc, T>.GetToString(), data);
             }
 
             if (options.ShouldPrettyPrint && options.IsJSONP && options.ShouldIncludeInherited)
@@ -290,9 +405,19 @@ namespace Jil
                 return WriteToString(TypeCache<NewtonsoftStylePrettyPrintJSONPInherited, T>.GetToString(), data);
             }
 
+            if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<NewtonsoftStylePrettyPrintExcludeNullsInheritedNotConvertToUtc, T>.GetToString(), data);
+            }
+
             if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.ShouldIncludeInherited)
             {
                 return WriteToString(TypeCache<NewtonsoftStylePrettyPrintExcludeNullsInherited, T>.GetToString(), data);
+            }
+
+            if (options.ShouldExcludeNulls && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<NewtonsoftStyleExcludeNullsInheritedNotConvertToUtc, T>.GetToString(), data);
             }
 
             if (options.ShouldExcludeNulls && options.ShouldIncludeInherited)
@@ -300,9 +425,19 @@ namespace Jil
                 return WriteToString(TypeCache<NewtonsoftStyleExcludeNullsInherited, T>.GetToString(), data);
             }
 
+            if (options.ShouldExcludeNulls && options.IsJSONP && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<NewtonsoftStyleExcludeNullsJSONPNotConvertToUtc, T>.GetToString(), data);
+            }
+
             if (options.ShouldExcludeNulls && options.IsJSONP)
             {
                 return WriteToString(TypeCache<NewtonsoftStyleExcludeNullsJSONP, T>.GetToString(), data);
+            }
+
+            if (options.ShouldPrettyPrint && options.IsJSONP && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<NewtonsoftStylePrettyPrintJSONPNotConvertToUtc, T>.GetToString(), data);
             }
 
             if (options.ShouldPrettyPrint && options.IsJSONP)
@@ -310,9 +445,19 @@ namespace Jil
                 return WriteToString(TypeCache<NewtonsoftStylePrettyPrintJSONP, T>.GetToString(), data);
             }
 
+            if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<NewtonsoftStylePrettyPrintExcludeNullsNotConvertToUtc, T>.GetToString(), data);
+            }
+
             if (options.ShouldExcludeNulls && options.ShouldPrettyPrint)
             {
                 return WriteToString(TypeCache<NewtonsoftStylePrettyPrintExcludeNulls, T>.GetToString(), data);
+            }
+
+            if (options.ShouldPrettyPrint && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<NewtonsoftStylePrettyPrintInheritedNotConvertToUtc, T>.GetToString(), data);
             }
 
             if (options.ShouldPrettyPrint && options.ShouldIncludeInherited)
@@ -320,9 +465,19 @@ namespace Jil
                 return WriteToString(TypeCache<NewtonsoftStylePrettyPrintInherited, T>.GetToString(), data);
             }
 
+            if (options.IsJSONP && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<NewtonsoftStyleJSONPInheritedNotConvertToUtc, T>.GetToString(), data);
+            }
+
             if (options.IsJSONP && options.ShouldIncludeInherited)
             {
                 return WriteToString(TypeCache<NewtonsoftStyleJSONPInherited, T>.GetToString(), data);
+            }
+
+            if (options.ShouldExcludeNulls && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<NewtonsoftStyleExcludeNullsNotConvertToUtc, T>.GetToString(), data);
             }
 
             if (options.ShouldExcludeNulls)
@@ -330,9 +485,19 @@ namespace Jil
                 return WriteToString(TypeCache<NewtonsoftStyleExcludeNulls, T>.GetToString(), data);
             }
 
+            if (options.ShouldPrettyPrint && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<NewtonsoftStylePrettyPrintNotConvertToUtc, T>.GetToString(), data);
+            }
+
             if (options.ShouldPrettyPrint)
             {
                 return WriteToString(TypeCache<NewtonsoftStylePrettyPrint, T>.GetToString(), data);
+            }
+
+            if (options.IsJSONP && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<NewtonsoftStyleJSONPNotConvertToUtc, T>.GetToString(), data);
             }
 
             if (options.IsJSONP)
@@ -340,9 +505,19 @@ namespace Jil
                 return WriteToString(TypeCache<NewtonsoftStyleJSONP, T>.GetToString(), data);
             }
 
+            if (options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<NewtonsoftStyleInheritedNotConvertToUtc, T>.GetToString(), data);
+            }
+
             if (options.ShouldIncludeInherited)
             {
                 return WriteToString(TypeCache<NewtonsoftStyleInherited, T>.GetToString(), data);
+            }
+
+            if (!options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<NewtonsoftStyleNotConvertToUtc, T>.GetToString(), data);
             }
 
             return WriteToString(TypeCache<NewtonsoftStyle, T>.GetToString(), data);
@@ -350,9 +525,21 @@ namespace Jil
 
         static void Milliseconds<T>(T data, TextWriter output, Options options)
         {
+            if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.IsJSONP && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                TypeCache<MillisecondsPrettyPrintExcludeNullsJSONPInheritedNotConvertToUtc, T>.Get()(output, data, 0);
+                return;
+            }
+
             if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.IsJSONP && options.ShouldIncludeInherited)
             {
                 TypeCache<MillisecondsPrettyPrintExcludeNullsJSONPInherited, T>.Get()(output, data, 0);
+                return;
+            }
+
+            if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.IsJSONP && !options.ShouldConvertToUtc)
+            {
+                TypeCache<MillisecondsPrettyPrintExcludeNullsJSONPNotConvertToUtc, T>.Get()(output, data, 0);
                 return;
             }
 
@@ -362,9 +549,21 @@ namespace Jil
                 return;
             }
 
+            if (options.ShouldExcludeNulls && options.IsJSONP && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                TypeCache<MillisecondsExcludeNullsJSONPInheritedNotConvertToUtc, T>.Get()(output, data, 0);
+                return;
+            }
+
             if (options.ShouldExcludeNulls && options.IsJSONP && options.ShouldIncludeInherited)
             {
                 TypeCache<MillisecondsExcludeNullsJSONPInherited, T>.Get()(output, data, 0);
+                return;
+            }
+
+            if (options.ShouldPrettyPrint && options.IsJSONP && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                TypeCache<MillisecondsPrettyPrintJSONPInheritedNotConvertToUtc, T>.Get()(output, data, 0);
                 return;
             }
 
@@ -374,9 +573,21 @@ namespace Jil
                 return;
             }
 
+            if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                TypeCache<MillisecondsPrettyPrintExcludeNullsInheritedNotConvertToUtc, T>.Get()(output, data, 0);
+                return;
+            }
+
             if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.ShouldIncludeInherited)
             {
                 TypeCache<MillisecondsPrettyPrintExcludeNullsInherited, T>.Get()(output, data, 0);
+                return;
+            }
+
+            if (options.ShouldExcludeNulls && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                TypeCache<MillisecondsExcludeNullsInheritedNotConvertToUtc, T>.Get()(output, data, 0);
                 return;
             }
 
@@ -386,9 +597,21 @@ namespace Jil
                 return;
             }
 
+            if (options.ShouldExcludeNulls && options.IsJSONP && !options.ShouldConvertToUtc)
+            {
+                TypeCache<MillisecondsExcludeNullsJSONPNotConvertToUtc, T>.Get()(output, data, 0);
+                return;
+            }
+
             if (options.ShouldExcludeNulls && options.IsJSONP)
             {
                 TypeCache<MillisecondsExcludeNullsJSONP, T>.Get()(output, data, 0);
+                return;
+            }
+
+            if (options.ShouldPrettyPrint && options.IsJSONP && !options.ShouldConvertToUtc)
+            {
+                TypeCache<MillisecondsPrettyPrintJSONPNotConvertToUtc, T>.Get()(output, data, 0);
                 return;
             }
 
@@ -398,9 +621,21 @@ namespace Jil
                 return;
             }
 
+            if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && !options.ShouldConvertToUtc)
+            {
+                TypeCache<MillisecondsPrettyPrintExcludeNullsNotConvertToUtc, T>.Get()(output, data, 0);
+                return;
+            }
+
             if (options.ShouldExcludeNulls && options.ShouldPrettyPrint)
             {
                 TypeCache<MillisecondsPrettyPrintExcludeNulls, T>.Get()(output, data, 0);
+                return;
+            }
+
+            if (options.ShouldPrettyPrint && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                TypeCache<MillisecondsPrettyPrintInheritedNotConvertToUtc, T>.Get()(output, data, 0);
                 return;
             }
 
@@ -410,9 +645,21 @@ namespace Jil
                 return;
             }
 
+            if (options.IsJSONP && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                TypeCache<MillisecondsJSONPInheritedNotConvertToUtc, T>.Get()(output, data, 0);
+                return;
+            }
+
             if (options.IsJSONP && options.ShouldIncludeInherited)
             {
                 TypeCache<MillisecondsJSONPInherited, T>.Get()(output, data, 0);
+                return;
+            }
+
+            if (options.ShouldExcludeNulls && !options.ShouldConvertToUtc)
+            {
+                TypeCache<MillisecondsExcludeNullsNotConvertToUtc, T>.Get()(output, data, 0);
                 return;
             }
 
@@ -422,9 +669,21 @@ namespace Jil
                 return;
             }
 
+            if (options.ShouldPrettyPrint && !options.ShouldConvertToUtc)
+            {
+                TypeCache<MillisecondsPrettyPrintNotConvertToUtc, T>.Get()(output, data, 0);
+                return;
+            }
+
             if (options.ShouldPrettyPrint)
             {
                 TypeCache<MillisecondsPrettyPrint, T>.Get()(output, data, 0);
+                return;
+            }
+
+            if (options.IsJSONP && !options.ShouldConvertToUtc)
+            {
+                TypeCache<MillisecondsJSONPNotConvertToUtc, T>.Get()(output, data, 0);
                 return;
             }
 
@@ -434,9 +693,21 @@ namespace Jil
                 return;
             }
 
+            if (options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                TypeCache<MillisecondsInheritedNotConvertToUtc, T>.Get()(output, data, 0);
+                return;
+            }
+
             if (options.ShouldIncludeInherited)
             {
                 TypeCache<MillisecondsInherited, T>.Get()(output, data, 0);
+                return;
+            }
+
+            if(!options.ShouldConvertToUtc)
+            {
+                TypeCache<MillisecondsNotConvertToUtc, T>.Get()(output, data, 0);
                 return;
             }
 
@@ -445,9 +716,19 @@ namespace Jil
 
         static string MillisecondsToString<T>(T data, Options options)
         {
+            if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.IsJSONP && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<MillisecondsPrettyPrintExcludeNullsJSONPInheritedNotConvertToUtc, T>.GetToString(), data);
+            }
+
             if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.IsJSONP && options.ShouldIncludeInherited)
             {
                 return WriteToString(TypeCache<MillisecondsPrettyPrintExcludeNullsJSONPInherited, T>.GetToString(), data);
+            }
+
+            if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.IsJSONP && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<MillisecondsPrettyPrintExcludeNullsJSONPNotConvertToUtc, T>.GetToString(), data);
             }
 
             if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.IsJSONP)
@@ -455,9 +736,19 @@ namespace Jil
                 return WriteToString(TypeCache<MillisecondsPrettyPrintExcludeNullsJSONP, T>.GetToString(), data);
             }
 
+            if (options.ShouldExcludeNulls && options.IsJSONP && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<MillisecondsExcludeNullsJSONPInheritedNotConvertToUtc, T>.GetToString(), data);
+            }
+
             if (options.ShouldExcludeNulls && options.IsJSONP && options.ShouldIncludeInherited)
             {
                 return WriteToString(TypeCache<MillisecondsExcludeNullsJSONPInherited, T>.GetToString(), data);
+            }
+
+            if (options.ShouldPrettyPrint && options.IsJSONP && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<MillisecondsPrettyPrintJSONPInheritedNotConvertToUtc, T>.GetToString(), data);
             }
 
             if (options.ShouldPrettyPrint && options.IsJSONP && options.ShouldIncludeInherited)
@@ -465,9 +756,19 @@ namespace Jil
                 return WriteToString(TypeCache<MillisecondsPrettyPrintJSONPInherited, T>.GetToString(), data);
             }
 
+            if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<MillisecondsPrettyPrintExcludeNullsInheritedNotConvertToUtc, T>.GetToString(), data);
+            }
+
             if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.ShouldIncludeInherited)
             {
                 return WriteToString(TypeCache<MillisecondsPrettyPrintExcludeNullsInherited, T>.GetToString(), data);
+            }
+
+            if (options.ShouldExcludeNulls && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<MillisecondsExcludeNullsInheritedNotConvertToUtc, T>.GetToString(), data);
             }
 
             if (options.ShouldExcludeNulls && options.ShouldIncludeInherited)
@@ -475,9 +776,19 @@ namespace Jil
                 return WriteToString(TypeCache<MillisecondsExcludeNullsInherited, T>.GetToString(), data);
             }
 
+            if (options.ShouldExcludeNulls && options.IsJSONP && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<MillisecondsExcludeNullsJSONPNotConvertToUtc, T>.GetToString(), data);
+            }
+
             if (options.ShouldExcludeNulls && options.IsJSONP)
             {
                 return WriteToString(TypeCache<MillisecondsExcludeNullsJSONP, T>.GetToString(), data);
+            }
+
+            if (options.ShouldPrettyPrint && options.IsJSONP && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<MillisecondsPrettyPrintJSONPNotConvertToUtc, T>.GetToString(), data);
             }
 
             if (options.ShouldPrettyPrint && options.IsJSONP)
@@ -485,9 +796,19 @@ namespace Jil
                 return WriteToString(TypeCache<MillisecondsPrettyPrintJSONP, T>.GetToString(), data);
             }
 
+            if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<MillisecondsPrettyPrintExcludeNullsNotConvertToUtc, T>.GetToString(), data);
+            }
+
             if (options.ShouldExcludeNulls && options.ShouldPrettyPrint)
             {
                 return WriteToString(TypeCache<MillisecondsPrettyPrintExcludeNulls, T>.GetToString(), data);
+            }
+
+            if (options.ShouldPrettyPrint && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<MillisecondsPrettyPrintInheritedNotConvertToUtc, T>.GetToString(), data);
             }
 
             if (options.ShouldPrettyPrint && options.ShouldIncludeInherited)
@@ -495,9 +816,19 @@ namespace Jil
                 return WriteToString(TypeCache<MillisecondsPrettyPrintInherited, T>.GetToString(), data);
             }
 
+            if (options.IsJSONP && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<MillisecondsJSONPInheritedNotConvertToUtc, T>.GetToString(), data);
+            }
+
             if (options.IsJSONP && options.ShouldIncludeInherited)
             {
                 return WriteToString(TypeCache<MillisecondsJSONPInherited, T>.GetToString(), data);
+            }
+
+            if (options.ShouldExcludeNulls && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<MillisecondsExcludeNullsNotConvertToUtc, T>.GetToString(), data);
             }
 
             if (options.ShouldExcludeNulls)
@@ -505,9 +836,19 @@ namespace Jil
                 return WriteToString(TypeCache<MillisecondsExcludeNulls, T>.GetToString(), data);
             }
 
+            if (options.ShouldPrettyPrint && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<MillisecondsPrettyPrintNotConvertToUtc, T>.GetToString(), data);
+            }
+
             if (options.ShouldPrettyPrint)
             {
                 return WriteToString(TypeCache<MillisecondsPrettyPrint, T>.GetToString(), data);
+            }
+
+            if (options.IsJSONP && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<MillisecondsJSONPNotConvertToUtc, T>.GetToString(), data);
             }
 
             if (options.IsJSONP)
@@ -515,9 +856,19 @@ namespace Jil
                 return WriteToString(TypeCache<MillisecondsJSONP, T>.GetToString(), data);
             }
 
+            if (options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<MillisecondsInheritedNotConvertToUtc, T>.GetToString(), data);
+            }
+
             if (options.ShouldIncludeInherited)
             {
                 return WriteToString(TypeCache<MillisecondsInherited, T>.GetToString(), data);
+            }
+
+            if (!options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<MillisecondsNotConvertToUtc, T>.GetToString(), data);
             }
 
             return WriteToString(TypeCache<Milliseconds, T>.GetToString(), data);
@@ -525,9 +876,21 @@ namespace Jil
 
         static void Seconds<T>(T data, TextWriter output, Options options)
         {
+            if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.IsJSONP && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                TypeCache<SecondsPrettyPrintExcludeNullsJSONPInheritedNotConvertToUtc, T>.Get()(output, data, 0);
+                return;
+            }
+
             if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.IsJSONP && options.ShouldIncludeInherited)
             {
                 TypeCache<SecondsPrettyPrintExcludeNullsJSONPInherited, T>.Get()(output, data, 0);
+                return;
+            }
+
+            if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.IsJSONP && !options.ShouldConvertToUtc)
+            {
+                TypeCache<SecondsPrettyPrintExcludeNullsJSONPNotConvertToUtc, T>.Get()(output, data, 0);
                 return;
             }
 
@@ -537,9 +900,21 @@ namespace Jil
                 return;
             }
 
+            if (options.ShouldExcludeNulls && options.IsJSONP && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                TypeCache<SecondsExcludeNullsJSONPInheritedNotConvertToUtc, T>.Get()(output, data, 0);
+                return;
+            }
+
             if (options.ShouldExcludeNulls && options.IsJSONP && options.ShouldIncludeInherited)
             {
                 TypeCache<SecondsExcludeNullsJSONPInherited, T>.Get()(output, data, 0);
+                return;
+            }
+
+            if (options.ShouldPrettyPrint && options.IsJSONP && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                TypeCache<SecondsPrettyPrintJSONPInheritedNotConvertToUtc, T>.Get()(output, data, 0);
                 return;
             }
 
@@ -549,9 +924,21 @@ namespace Jil
                 return;
             }
 
+            if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                TypeCache<SecondsPrettyPrintExcludeNullsInheritedNotConvertToUtc, T>.Get()(output, data, 0);
+                return;
+            }
+
             if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.ShouldIncludeInherited)
             {
                 TypeCache<SecondsPrettyPrintExcludeNullsInherited, T>.Get()(output, data, 0);
+                return;
+            }
+
+            if (options.ShouldExcludeNulls && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                TypeCache<SecondsExcludeNullsInheritedNotConvertToUtc, T>.Get()(output, data, 0);
                 return;
             }
 
@@ -561,9 +948,21 @@ namespace Jil
                 return;
             }
 
+            if (options.ShouldExcludeNulls && options.IsJSONP && !options.ShouldConvertToUtc)
+            {
+                TypeCache<SecondsExcludeNullsJSONPNotConvertToUtc, T>.Get()(output, data, 0);
+                return;
+            }
+
             if (options.ShouldExcludeNulls && options.IsJSONP)
             {
                 TypeCache<SecondsExcludeNullsJSONP, T>.Get()(output, data, 0);
+                return;
+            }
+
+            if (options.ShouldPrettyPrint && options.IsJSONP && !options.ShouldConvertToUtc)
+            {
+                TypeCache<SecondsPrettyPrintJSONPNotConvertToUtc, T>.Get()(output, data, 0);
                 return;
             }
 
@@ -573,9 +972,21 @@ namespace Jil
                 return;
             }
 
+            if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && !options.ShouldConvertToUtc)
+            {
+                TypeCache<SecondsPrettyPrintExcludeNullsNotConvertToUtc, T>.Get()(output, data, 0);
+                return;
+            }
+
             if (options.ShouldExcludeNulls && options.ShouldPrettyPrint)
             {
                 TypeCache<SecondsPrettyPrintExcludeNulls, T>.Get()(output, data, 0);
+                return;
+            }
+
+            if (options.ShouldPrettyPrint && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                TypeCache<SecondsPrettyPrintInheritedNotConvertToUtc, T>.Get()(output, data, 0);
                 return;
             }
 
@@ -585,9 +996,21 @@ namespace Jil
                 return;
             }
 
+            if (options.IsJSONP && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                TypeCache<SecondsJSONPInheritedNotConvertToUtc, T>.Get()(output, data, 0);
+                return;
+            }
+
             if (options.IsJSONP && options.ShouldIncludeInherited)
             {
                 TypeCache<SecondsJSONPInherited, T>.Get()(output, data, 0);
+                return;
+            }
+
+            if (options.ShouldExcludeNulls && !options.ShouldConvertToUtc)
+            {
+                TypeCache<SecondsExcludeNullsNotConvertToUtc, T>.Get()(output, data, 0);
                 return;
             }
 
@@ -597,9 +1020,21 @@ namespace Jil
                 return;
             }
 
+            if (options.ShouldPrettyPrint && !options.ShouldConvertToUtc)
+            {
+                TypeCache<SecondsPrettyPrintNotConvertToUtc, T>.Get()(output, data, 0);
+                return;
+            }
+
             if (options.ShouldPrettyPrint)
             {
                 TypeCache<SecondsPrettyPrint, T>.Get()(output, data, 0);
+                return;
+            }
+
+            if (options.IsJSONP && !options.ShouldConvertToUtc)
+            {
+                TypeCache<SecondsJSONPNotConvertToUtc, T>.Get()(output, data, 0);
                 return;
             }
 
@@ -609,9 +1044,21 @@ namespace Jil
                 return;
             }
 
+            if (options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                TypeCache<SecondsInheritedNotConvertToUtc, T>.Get()(output, data, 0);
+                return;
+            }
+
             if (options.ShouldIncludeInherited)
             {
                 TypeCache<SecondsInherited, T>.Get()(output, data, 0);
+                return;
+            }
+
+            if(!options.ShouldConvertToUtc)
+            {
+                TypeCache<SecondsNotConvertToUtc, T>.Get()(output, data, 0);
                 return;
             }
 
@@ -620,9 +1067,19 @@ namespace Jil
 
         static string SecondsToString<T>(T data, Options options)
         {
+            if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.IsJSONP && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<SecondsPrettyPrintExcludeNullsJSONPInheritedNotConvertToUtc, T>.GetToString(), data);
+            }
+
             if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.IsJSONP && options.ShouldIncludeInherited)
             {
                 return WriteToString(TypeCache<SecondsPrettyPrintExcludeNullsJSONPInherited, T>.GetToString(), data);
+            }
+
+            if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.IsJSONP && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<SecondsPrettyPrintExcludeNullsJSONPNotConvertToUtc, T>.GetToString(), data);
             }
 
             if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.IsJSONP)
@@ -630,9 +1087,19 @@ namespace Jil
                 return WriteToString(TypeCache<SecondsPrettyPrintExcludeNullsJSONP, T>.GetToString(), data);
             }
 
+            if (options.ShouldExcludeNulls && options.IsJSONP && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<SecondsExcludeNullsJSONPInheritedNotConvertToUtc, T>.GetToString(), data);
+            }
+
             if (options.ShouldExcludeNulls && options.IsJSONP && options.ShouldIncludeInherited)
             {
                 return WriteToString(TypeCache<SecondsExcludeNullsJSONPInherited, T>.GetToString(), data);
+            }
+
+            if (options.ShouldPrettyPrint && options.IsJSONP && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<SecondsPrettyPrintJSONPInheritedNotConvertToUtc, T>.GetToString(), data);
             }
 
             if (options.ShouldPrettyPrint && options.IsJSONP && options.ShouldIncludeInherited)
@@ -640,9 +1107,19 @@ namespace Jil
                 return WriteToString(TypeCache<SecondsPrettyPrintJSONPInherited, T>.GetToString(), data);
             }
 
+            if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<SecondsPrettyPrintExcludeNullsInheritedNotConvertToUtc, T>.GetToString(), data);
+            }
+
             if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.ShouldIncludeInherited)
             {
                 return WriteToString(TypeCache<SecondsPrettyPrintExcludeNullsInherited, T>.GetToString(), data);
+            }
+
+            if (options.ShouldExcludeNulls && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<SecondsExcludeNullsInheritedNotConvertToUtc, T>.GetToString(), data);
             }
 
             if (options.ShouldExcludeNulls && options.ShouldIncludeInherited)
@@ -650,9 +1127,19 @@ namespace Jil
                 return WriteToString(TypeCache<SecondsExcludeNullsInherited, T>.GetToString(), data);
             }
 
+            if (options.ShouldExcludeNulls && options.IsJSONP && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<SecondsExcludeNullsJSONPNotConvertToUtc, T>.GetToString(), data);
+            }
+
             if (options.ShouldExcludeNulls && options.IsJSONP)
             {
                 return WriteToString(TypeCache<SecondsExcludeNullsJSONP, T>.GetToString(), data);
+            }
+
+            if (options.ShouldPrettyPrint && options.IsJSONP && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<SecondsPrettyPrintJSONPNotConvertToUtc, T>.GetToString(), data);
             }
 
             if (options.ShouldPrettyPrint && options.IsJSONP)
@@ -660,9 +1147,19 @@ namespace Jil
                 return WriteToString(TypeCache<SecondsPrettyPrintJSONP, T>.GetToString(), data);
             }
 
+            if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<SecondsPrettyPrintExcludeNullsNotConvertToUtc, T>.GetToString(), data);
+            }
+
             if (options.ShouldExcludeNulls && options.ShouldPrettyPrint)
             {
                 return WriteToString(TypeCache<SecondsPrettyPrintExcludeNulls, T>.GetToString(), data);
+            }
+
+            if (options.ShouldPrettyPrint && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<SecondsPrettyPrintInheritedNotConvertToUtc, T>.GetToString(), data);
             }
 
             if (options.ShouldPrettyPrint && options.ShouldIncludeInherited)
@@ -670,9 +1167,19 @@ namespace Jil
                 return WriteToString(TypeCache<SecondsPrettyPrintInherited, T>.GetToString(), data);
             }
 
+            if (options.IsJSONP && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<SecondsJSONPInheritedNotConvertToUtc, T>.GetToString(), data);
+            }
+
             if (options.IsJSONP && options.ShouldIncludeInherited)
             {
                 return WriteToString(TypeCache<SecondsJSONPInherited, T>.GetToString(), data);
+            }
+
+            if (options.ShouldExcludeNulls && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<SecondsExcludeNullsNotConvertToUtc, T>.GetToString(), data);
             }
 
             if (options.ShouldExcludeNulls)
@@ -680,9 +1187,19 @@ namespace Jil
                 return WriteToString(TypeCache<SecondsExcludeNulls, T>.GetToString(), data);
             }
 
+            if (options.ShouldPrettyPrint && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<SecondsPrettyPrintNotConvertToUtc, T>.GetToString(), data);
+            }
+
             if (options.ShouldPrettyPrint)
             {
                 return WriteToString(TypeCache<SecondsPrettyPrint, T>.GetToString(), data);
+            }
+
+            if (options.IsJSONP && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<SecondsJSONPNotConvertToUtc, T>.GetToString(), data);
             }
 
             if (options.IsJSONP)
@@ -690,9 +1207,19 @@ namespace Jil
                 return WriteToString(TypeCache<SecondsJSONP, T>.GetToString(), data);
             }
 
+            if (options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<SecondsInheritedNotConvertToUtc, T>.GetToString(), data);
+            }
+
             if (options.ShouldIncludeInherited)
             {
                 return WriteToString(TypeCache<SecondsInherited, T>.GetToString(), data);
+            }
+
+            if (!options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<SecondsNotConvertToUtc, T>.GetToString(), data);
             }
 
             return WriteToString(TypeCache<Seconds, T>.GetToString(), data);
@@ -700,9 +1227,21 @@ namespace Jil
 
         static void ISO8601<T>(T data, TextWriter output, Options options)
         {
+            if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.IsJSONP && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                TypeCache<ISO8601PrettyPrintExcludeNullsJSONPInheritedNotConvertToUtc, T>.Get()(output, data, 0);
+                return;
+            }
+
             if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.IsJSONP && options.ShouldIncludeInherited)
             {
                 TypeCache<ISO8601PrettyPrintExcludeNullsJSONPInherited, T>.Get()(output, data, 0);
+                return;
+            }
+
+            if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.IsJSONP && !options.ShouldConvertToUtc)
+            {
+                TypeCache<ISO8601PrettyPrintExcludeNullsJSONPNotConvertToUtc, T>.Get()(output, data, 0);
                 return;
             }
 
@@ -712,9 +1251,21 @@ namespace Jil
                 return;
             }
 
+            if (options.ShouldExcludeNulls && options.IsJSONP && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                TypeCache<ISO8601ExcludeNullsJSONPInheritedNotConvertToUtc, T>.Get()(output, data, 0);
+                return;
+            }
+
             if (options.ShouldExcludeNulls && options.IsJSONP && options.ShouldIncludeInherited)
             {
                 TypeCache<ISO8601ExcludeNullsJSONPInherited, T>.Get()(output, data, 0);
+                return;
+            }
+
+            if (options.ShouldPrettyPrint && options.IsJSONP && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                TypeCache<ISO8601PrettyPrintJSONPInheritedNotConvertToUtc, T>.Get()(output, data, 0);
                 return;
             }
 
@@ -724,9 +1275,21 @@ namespace Jil
                 return;
             }
 
+            if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                TypeCache<ISO8601PrettyPrintExcludeNullsInheritedNotConvertToUtc, T>.Get()(output, data, 0);
+                return;
+            }
+
             if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.ShouldIncludeInherited)
             {
                 TypeCache<ISO8601PrettyPrintExcludeNullsInherited, T>.Get()(output, data, 0);
+                return;
+            }
+
+            if (options.ShouldExcludeNulls && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                TypeCache<ISO8601ExcludeNullsInheritedNotConvertToUtc, T>.Get()(output, data, 0);
                 return;
             }
 
@@ -736,9 +1299,21 @@ namespace Jil
                 return;
             }
 
+            if (options.ShouldExcludeNulls && options.IsJSONP && !options.ShouldConvertToUtc)
+            {
+                TypeCache<ISO8601ExcludeNullsJSONPNotConvertToUtc, T>.Get()(output, data, 0);
+                return;
+            }
+
             if (options.ShouldExcludeNulls && options.IsJSONP)
             {
                 TypeCache<ISO8601ExcludeNullsJSONP, T>.Get()(output, data, 0);
+                return;
+            }
+
+            if (options.ShouldPrettyPrint && options.IsJSONP && !options.ShouldConvertToUtc)
+            {
+                TypeCache<ISO8601PrettyPrintJSONPNotConvertToUtc, T>.Get()(output, data, 0);
                 return;
             }
 
@@ -748,9 +1323,21 @@ namespace Jil
                 return;
             }
 
+            if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && !options.ShouldConvertToUtc)
+            {
+                TypeCache<ISO8601PrettyPrintExcludeNullsNotConvertToUtc, T>.Get()(output, data, 0);
+                return;
+            }
+
             if (options.ShouldExcludeNulls && options.ShouldPrettyPrint)
             {
                 TypeCache<ISO8601PrettyPrintExcludeNulls, T>.Get()(output, data, 0);
+                return;
+            }
+
+            if (options.ShouldPrettyPrint && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                TypeCache<ISO8601PrettyPrintInheritedNotConvertToUtc, T>.Get()(output, data, 0);
                 return;
             }
 
@@ -760,9 +1347,21 @@ namespace Jil
                 return;
             }
 
+            if (options.IsJSONP && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                TypeCache<ISO8601JSONPInheritedNotConvertToUtc, T>.Get()(output, data, 0);
+                return;
+            }
+
             if (options.IsJSONP && options.ShouldIncludeInherited)
             {
                 TypeCache<ISO8601JSONPInherited, T>.Get()(output, data, 0);
+                return;
+            }
+
+            if (options.ShouldExcludeNulls && !options.ShouldConvertToUtc)
+            {
+                TypeCache<ISO8601ExcludeNullsNotConvertToUtc, T>.Get()(output, data, 0);
                 return;
             }
 
@@ -772,9 +1371,21 @@ namespace Jil
                 return;
             }
 
+            if (options.ShouldPrettyPrint && !options.ShouldConvertToUtc)
+            {
+                TypeCache<ISO8601PrettyPrintNotConvertToUtc, T>.Get()(output, data, 0);
+                return;
+            }
+
             if (options.ShouldPrettyPrint)
             {
                 TypeCache<ISO8601PrettyPrint, T>.Get()(output, data, 0);
+                return;
+            }
+
+            if (options.IsJSONP && !options.ShouldConvertToUtc)
+            {
+                TypeCache<ISO8601JSONPNotConvertToUtc, T>.Get()(output, data, 0);
                 return;
             }
 
@@ -784,9 +1395,21 @@ namespace Jil
                 return;
             }
 
+            if (options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                TypeCache<ISO8601InheritedNotConvertToUtc, T>.Get()(output, data, 0);
+                return;
+            }
+
             if (options.ShouldIncludeInherited)
             {
                 TypeCache<ISO8601Inherited, T>.Get()(output, data, 0);
+                return;
+            }
+
+            if (!options.ShouldConvertToUtc)
+            {
+                TypeCache<ISO8601NotConvertToUtc, T>.Get()(output, data, 0);
                 return;
             }
 
@@ -795,9 +1418,19 @@ namespace Jil
 
         static string ISO8601ToString<T>(T data, Options options)
         {
+            if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.IsJSONP && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<ISO8601PrettyPrintExcludeNullsJSONPInheritedNotConvertToUtc, T>.GetToString(), data);
+            }
+
             if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.IsJSONP && options.ShouldIncludeInherited)
             {
                 return WriteToString(TypeCache<ISO8601PrettyPrintExcludeNullsJSONPInherited, T>.GetToString(), data);
+            }
+
+            if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.IsJSONP && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<ISO8601PrettyPrintExcludeNullsJSONPNotConvertToUtc, T>.GetToString(), data);
             }
 
             if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.IsJSONP)
@@ -805,9 +1438,19 @@ namespace Jil
                 return WriteToString(TypeCache<ISO8601PrettyPrintExcludeNullsJSONP, T>.GetToString(), data);
             }
 
+            if (options.ShouldExcludeNulls && options.IsJSONP && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<ISO8601ExcludeNullsJSONPInheritedNotConvertToUtc, T>.GetToString(), data);
+            }
+
             if (options.ShouldExcludeNulls && options.IsJSONP && options.ShouldIncludeInherited)
             {
                 return WriteToString(TypeCache<ISO8601ExcludeNullsJSONPInherited, T>.GetToString(), data);
+            }
+
+            if (options.ShouldPrettyPrint && options.IsJSONP && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<ISO8601PrettyPrintJSONPInheritedNotConvertToUtc, T>.GetToString(), data);
             }
 
             if (options.ShouldPrettyPrint && options.IsJSONP && options.ShouldIncludeInherited)
@@ -815,9 +1458,19 @@ namespace Jil
                 return WriteToString(TypeCache<ISO8601PrettyPrintJSONPInherited, T>.GetToString(), data);
             }
 
+            if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<ISO8601PrettyPrintExcludeNullsInheritedNotConvertToUtc, T>.GetToString(), data);
+            }
+
             if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && options.ShouldIncludeInherited)
             {
                 return WriteToString(TypeCache<ISO8601PrettyPrintExcludeNullsInherited, T>.GetToString(), data);
+            }
+
+            if (options.ShouldExcludeNulls && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<ISO8601ExcludeNullsInheritedNotConvertToUtc, T>.GetToString(), data);
             }
 
             if (options.ShouldExcludeNulls && options.ShouldIncludeInherited)
@@ -825,9 +1478,19 @@ namespace Jil
                 return WriteToString(TypeCache<ISO8601ExcludeNullsInherited, T>.GetToString(), data);
             }
 
+            if (options.ShouldExcludeNulls && options.IsJSONP && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<ISO8601ExcludeNullsJSONPNotConvertToUtc, T>.GetToString(), data);
+            }
+
             if (options.ShouldExcludeNulls && options.IsJSONP)
             {
                 return WriteToString(TypeCache<ISO8601ExcludeNullsJSONP, T>.GetToString(), data);
+            }
+
+            if (options.ShouldPrettyPrint && options.IsJSONP && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<ISO8601PrettyPrintJSONPNotConvertToUtc, T>.GetToString(), data);
             }
 
             if (options.ShouldPrettyPrint && options.IsJSONP)
@@ -835,9 +1498,19 @@ namespace Jil
                 return WriteToString(TypeCache<ISO8601PrettyPrintJSONP, T>.GetToString(), data);
             }
 
+            if (options.ShouldExcludeNulls && options.ShouldPrettyPrint && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<ISO8601PrettyPrintExcludeNullsNotConvertToUtc, T>.GetToString(), data);
+            }
+
             if (options.ShouldExcludeNulls && options.ShouldPrettyPrint)
             {
                 return WriteToString(TypeCache<ISO8601PrettyPrintExcludeNulls, T>.GetToString(), data);
+            }
+
+            if (options.ShouldPrettyPrint && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<ISO8601PrettyPrintInheritedNotConvertToUtc, T>.GetToString(), data);
             }
 
             if (options.ShouldPrettyPrint && options.ShouldIncludeInherited)
@@ -845,9 +1518,19 @@ namespace Jil
                 return WriteToString(TypeCache<ISO8601PrettyPrintInherited, T>.GetToString(), data);
             }
 
+            if (options.IsJSONP && options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<ISO8601JSONPInheritedNotConvertToUtc, T>.GetToString(), data);
+            }
+
             if (options.IsJSONP && options.ShouldIncludeInherited)
             {
                 return WriteToString(TypeCache<ISO8601JSONPInherited, T>.GetToString(), data);
+            }
+
+            if (options.ShouldExcludeNulls && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<ISO8601ExcludeNullsNotConvertToUtc, T>.GetToString(), data);
             }
 
             if (options.ShouldExcludeNulls)
@@ -855,9 +1538,19 @@ namespace Jil
                 return WriteToString(TypeCache<ISO8601ExcludeNulls, T>.GetToString(), data);
             }
 
+            if (options.ShouldPrettyPrint && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<ISO8601PrettyPrintNotConvertToUtc, T>.GetToString(), data);
+            }
+
             if (options.ShouldPrettyPrint)
             {
                 return WriteToString(TypeCache<ISO8601PrettyPrint, T>.GetToString(), data);
+            }
+
+            if (options.IsJSONP && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<ISO8601JSONPNotConvertToUtc, T>.GetToString(), data);
             }
 
             if (options.IsJSONP)
@@ -865,9 +1558,19 @@ namespace Jil
                 return WriteToString(TypeCache<ISO8601JSONP, T>.GetToString(), data);
             }
 
+            if (options.ShouldIncludeInherited && !options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<ISO8601InheritedNotConvertToUtc, T>.GetToString(), data);
+            }
+
             if (options.ShouldIncludeInherited)
             {
                 return WriteToString(TypeCache<ISO8601Inherited, T>.GetToString(), data);
+            }
+
+            if (!options.ShouldConvertToUtc)
+            {
+                return WriteToString(TypeCache<ISO8601, T>.GetToString(), data);
             }
 
             return WriteToString(TypeCache<ISO8601, T>.GetToString(), data);

--- a/Jil/Options.cs
+++ b/Jil/Options.cs
@@ -51,17 +51,12 @@ namespace Jil
         public static readonly Options ISO8601ExcludeNulls = new Options(dateFormat: DateTimeFormat.ISO8601, excludeNulls: true);
         public static readonly Options ISO8601JSONP = new Options(dateFormat: DateTimeFormat.ISO8601, jsonp: true);
         public static readonly Options ISO8601IncludeInherited = new Options(dateFormat: DateTimeFormat.ISO8601, includeInherited: true);
-        public static readonly Options ISO8601NotConvertToUtc = new Options(dateFormat: DateTimeFormat.ISO8601, iso8601ShouldNotConvertToUtc: true);
         public static readonly Options ISO8601PrettyPrintExcludeNulls = new Options(dateFormat: DateTimeFormat.ISO8601, prettyPrint: true, excludeNulls: true);
         public static readonly Options ISO8601PrettyPrintJSONP = new Options(dateFormat: DateTimeFormat.ISO8601, prettyPrint: true, jsonp: true);
         public static readonly Options ISO8601PrettyPrintIncludeInherited = new Options(dateFormat: DateTimeFormat.ISO8601, prettyPrint: true, includeInherited: true);
-        public static readonly Options ISO8601PrettyPrintNotConvertToUtc = new Options(dateFormat: DateTimeFormat.ISO8601, prettyPrint: true, iso8601ShouldNotConvertToUtc: true);
         public static readonly Options ISO8601ExcludeNullsJSONP = new Options(dateFormat: DateTimeFormat.ISO8601, excludeNulls: true, jsonp: true);
         public static readonly Options ISO8601ExcludeNullsIncludeInherited = new Options(dateFormat: DateTimeFormat.ISO8601, excludeNulls: true, includeInherited: true);
-        public static readonly Options ISO8601ExcludeNullsNotConvertToUtc = new Options(dateFormat: DateTimeFormat.ISO8601, excludeNulls: true, iso8601ShouldNotConvertToUtc: true);
         public static readonly Options ISO8601JSONPIncludeInherited = new Options(dateFormat: DateTimeFormat.ISO8601, jsonp: true, includeInherited: true);
-        public static readonly Options ISO8601JSONPNotConvertToUtc = new Options(dateFormat: DateTimeFormat.ISO8601, jsonp: true, iso8601ShouldNotConvertToUtc: true);
-        public static readonly Options ISO8601IncludeInheritedNotConvertToUtc = new Options(dateFormat: DateTimeFormat.ISO8601, includeInherited: true, iso8601ShouldNotConvertToUtc: true);
         public static readonly Options ISO8601PrettyPrintExcludeNullsJSONP = new Options(dateFormat: DateTimeFormat.ISO8601, prettyPrint: true, excludeNulls: true, jsonp: true);
         public static readonly Options ISO8601PrettyPrintExcludeNullsIncludeInherited = new Options(dateFormat: DateTimeFormat.ISO8601, prettyPrint: true, excludeNulls: true, includeInherited: true);
         public static readonly Options ISO8601PrettyPrintJSONPIncludeInherited = new Options(dateFormat: DateTimeFormat.ISO8601, jsonp: true, includeInherited: true);
@@ -92,7 +87,7 @@ namespace Jil
         internal DateTimeFormat UseDateTimeFormat { get; private set; }
         internal bool IsJSONP { get; private set; }
         internal bool ShouldIncludeInherited { get; private set; }
-        internal bool ISO8601ShouldNotConvertToUtc { get; private set; }
+        internal bool ShouldConvertToUtc { get; private set; }
 
         /// <summary>
         /// Configuration for Jil serialization options.
@@ -106,14 +101,14 @@ namespace Jil
         ///   allowHashFunction - whether or not Jil should try to use hashes instead of strings when deserializing object members, malicious content may be able to force member collisions if this is enabled
         /// </summary>
         public Options(bool prettyPrint = false, bool excludeNulls = false, bool jsonp = false, DateTimeFormat dateFormat = DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch, bool includeInherited = false,
-            bool iso8601ShouldNotConvertToUtc = false)
+            bool shouldConvertToUtc = true)
         {
             ShouldPrettyPrint = prettyPrint;
             ShouldExcludeNulls = excludeNulls;
             IsJSONP = jsonp;
             UseDateTimeFormat = dateFormat;
             ShouldIncludeInherited = includeInherited;
-            ISO8601ShouldNotConvertToUtc = iso8601ShouldNotConvertToUtc;
+            ShouldConvertToUtc = shouldConvertToUtc;
         }
 
         /// <summary>
@@ -125,13 +120,13 @@ namespace Jil
         {
             return
                 string.Format(
-                    "{{ ShouldPrettyPrint = {0}, ShouldExcludeNulls = {1}, UseDateTimeFormat = {2}, IsJSONP = {3}, ShouldIncludeInherited = {4}, ISO8601ShouldNotConvertToUtc = {5} }}",
+                    "{{ ShouldPrettyPrint = {0}, ShouldExcludeNulls = {1}, UseDateTimeFormat = {2}, IsJSONP = {3}, ShouldIncludeInherited = {4}, ShouldConvertToUtc = {5} }}",
                     ShouldPrettyPrint,
                     ShouldExcludeNulls,
                     UseDateTimeFormat,
                     IsJSONP,
                     ShouldIncludeInherited,
-                    ISO8601ShouldNotConvertToUtc
+                    ShouldConvertToUtc
                 );
         }
 
@@ -155,7 +150,7 @@ namespace Jil
                 (ShouldExcludeNulls ? 0x2 : 0x0) |
                 (IsJSONP ? 0x4 : 0x0) |
                 (ShouldIncludeInherited ? 0x8 : 0x0) |
-                (ISO8601ShouldNotConvertToUtc ? 0x16 : 0x0) |
+                (ShouldConvertToUtc ? 0x16 : 0x0) |
                 dateTimeMask;
         }
 
@@ -173,7 +168,7 @@ namespace Jil
                 other.ShouldExcludeNulls == this.ShouldExcludeNulls &&
                 other.IsJSONP == this.IsJSONP &&
                 other.ShouldIncludeInherited == this.ShouldIncludeInherited &&
-                other.ISO8601ShouldNotConvertToUtc == this.ISO8601ShouldNotConvertToUtc;
+                other.ShouldConvertToUtc == this.ShouldConvertToUtc;
         }
     }
 }

--- a/Jil/Options.cs
+++ b/Jil/Options.cs
@@ -45,22 +45,29 @@ namespace Jil
         public static readonly Options MillisecondsSinceUnixEpochExcludeNullsJSONPIncludeInherited = new Options(dateFormat: DateTimeFormat.MillisecondsSinceUnixEpoch, excludeNulls: true, jsonp: true, includeInherited: true);
         public static readonly Options MillisecondsSinceUnixEpochPrettyPrintExcludeNullsJSONPIncludeInherited = new Options(dateFormat: DateTimeFormat.MillisecondsSinceUnixEpoch, prettyPrint: true, excludeNulls: true, jsonp: true, includeInherited: true);
 
+
         public static readonly Options ISO8601 = new Options(dateFormat: DateTimeFormat.ISO8601);
         public static readonly Options ISO8601PrettyPrint = new Options(dateFormat: DateTimeFormat.ISO8601, prettyPrint: true);
         public static readonly Options ISO8601ExcludeNulls = new Options(dateFormat: DateTimeFormat.ISO8601, excludeNulls: true);
         public static readonly Options ISO8601JSONP = new Options(dateFormat: DateTimeFormat.ISO8601, jsonp: true);
         public static readonly Options ISO8601IncludeInherited = new Options(dateFormat: DateTimeFormat.ISO8601, includeInherited: true);
+        public static readonly Options ISO8601NotConvertToUtc = new Options(dateFormat: DateTimeFormat.ISO8601, iso8601ShouldNotConvertToUtc: true);
         public static readonly Options ISO8601PrettyPrintExcludeNulls = new Options(dateFormat: DateTimeFormat.ISO8601, prettyPrint: true, excludeNulls: true);
         public static readonly Options ISO8601PrettyPrintJSONP = new Options(dateFormat: DateTimeFormat.ISO8601, prettyPrint: true, jsonp: true);
         public static readonly Options ISO8601PrettyPrintIncludeInherited = new Options(dateFormat: DateTimeFormat.ISO8601, prettyPrint: true, includeInherited: true);
+        public static readonly Options ISO8601PrettyPrintNotConvertToUtc = new Options(dateFormat: DateTimeFormat.ISO8601, prettyPrint: true, iso8601ShouldNotConvertToUtc: true);
         public static readonly Options ISO8601ExcludeNullsJSONP = new Options(dateFormat: DateTimeFormat.ISO8601, excludeNulls: true, jsonp: true);
         public static readonly Options ISO8601ExcludeNullsIncludeInherited = new Options(dateFormat: DateTimeFormat.ISO8601, excludeNulls: true, includeInherited: true);
+        public static readonly Options ISO8601ExcludeNullsNotConvertToUtc = new Options(dateFormat: DateTimeFormat.ISO8601, excludeNulls: true, iso8601ShouldNotConvertToUtc: true);
         public static readonly Options ISO8601JSONPIncludeInherited = new Options(dateFormat: DateTimeFormat.ISO8601, jsonp: true, includeInherited: true);
+        public static readonly Options ISO8601JSONPNotConvertToUtc = new Options(dateFormat: DateTimeFormat.ISO8601, jsonp: true, iso8601ShouldNotConvertToUtc: true);
+        public static readonly Options ISO8601IncludeInheritedNotConvertToUtc = new Options(dateFormat: DateTimeFormat.ISO8601, includeInherited: true, iso8601ShouldNotConvertToUtc: true);
         public static readonly Options ISO8601PrettyPrintExcludeNullsJSONP = new Options(dateFormat: DateTimeFormat.ISO8601, prettyPrint: true, excludeNulls: true, jsonp: true);
         public static readonly Options ISO8601PrettyPrintExcludeNullsIncludeInherited = new Options(dateFormat: DateTimeFormat.ISO8601, prettyPrint: true, excludeNulls: true, includeInherited: true);
         public static readonly Options ISO8601PrettyPrintJSONPIncludeInherited = new Options(dateFormat: DateTimeFormat.ISO8601, jsonp: true, includeInherited: true);
         public static readonly Options ISO8601ExcludeNullsJSONPIncludeInherited = new Options(dateFormat: DateTimeFormat.ISO8601, excludeNulls: true, jsonp: true, includeInherited: true);
         public static readonly Options ISO8601PrettyPrintExcludeNullsJSONPIncludeInherited = new Options(dateFormat: DateTimeFormat.ISO8601, prettyPrint: true, excludeNulls: true, jsonp: true, includeInherited: true);
+
 
         public static readonly Options SecondsSinceUnixEpoch = new Options(dateFormat: DateTimeFormat.SecondsSinceUnixEpoch);
         public static readonly Options SecondsSinceUnixEpochPrettyPrint = new Options(dateFormat: DateTimeFormat.SecondsSinceUnixEpoch, prettyPrint: true);
@@ -106,7 +113,7 @@ namespace Jil
             IsJSONP = jsonp;
             UseDateTimeFormat = dateFormat;
             ShouldIncludeInherited = includeInherited;
-            ISO8601ShouldNotConvertToUtc = false;
+            ISO8601ShouldNotConvertToUtc = iso8601ShouldNotConvertToUtc;
         }
 
         /// <summary>
@@ -118,12 +125,13 @@ namespace Jil
         {
             return
                 string.Format(
-                    "{{ ShouldPrettyPrint = {0}, ShouldExcludeNulls = {1}, UseDateTimeFormat = {2}, IsJSONP = {3}, ShouldIncludeInherited = {4}, AllowHashFunction = {5} }}",
+                    "{{ ShouldPrettyPrint = {0}, ShouldExcludeNulls = {1}, UseDateTimeFormat = {2}, IsJSONP = {3}, ShouldIncludeInherited = {4}, ISO8601ShouldNotConvertToUtc = {5} }}",
                     ShouldPrettyPrint,
                     ShouldExcludeNulls,
                     UseDateTimeFormat,
                     IsJSONP,
-                    ShouldIncludeInherited
+                    ShouldIncludeInherited,
+                    ISO8601ShouldNotConvertToUtc
                 );
         }
 
@@ -147,6 +155,7 @@ namespace Jil
                 (ShouldExcludeNulls ? 0x2 : 0x0) |
                 (IsJSONP ? 0x4 : 0x0) |
                 (ShouldIncludeInherited ? 0x8 : 0x0) |
+                (ISO8601ShouldNotConvertToUtc ? 0x16 : 0x0) |
                 dateTimeMask;
         }
 
@@ -163,7 +172,8 @@ namespace Jil
                 other.ShouldPrettyPrint == this.ShouldPrettyPrint &&
                 other.ShouldExcludeNulls == this.ShouldExcludeNulls &&
                 other.IsJSONP == this.IsJSONP &&
-                other.ShouldIncludeInherited == this.ShouldIncludeInherited;
+                other.ShouldIncludeInherited == this.ShouldIncludeInherited &&
+                other.ISO8601ShouldNotConvertToUtc == this.ISO8601ShouldNotConvertToUtc;
         }
     }
 }

--- a/Jil/Options.cs
+++ b/Jil/Options.cs
@@ -85,6 +85,7 @@ namespace Jil
         internal DateTimeFormat UseDateTimeFormat { get; private set; }
         internal bool IsJSONP { get; private set; }
         internal bool ShouldIncludeInherited { get; private set; }
+        internal bool ISO8601ShouldNotConvertToUtc { get; private set; }
 
         /// <summary>
         /// Configuration for Jil serialization options.
@@ -97,13 +98,15 @@ namespace Jil
         ///   includeInherited - whether or not to serialize members declared by an objects base types
         ///   allowHashFunction - whether or not Jil should try to use hashes instead of strings when deserializing object members, malicious content may be able to force member collisions if this is enabled
         /// </summary>
-        public Options(bool prettyPrint = false, bool excludeNulls = false, bool jsonp = false, DateTimeFormat dateFormat = DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch, bool includeInherited = false)
+        public Options(bool prettyPrint = false, bool excludeNulls = false, bool jsonp = false, DateTimeFormat dateFormat = DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch, bool includeInherited = false,
+            bool iso8601ShouldNotConvertToUtc = false)
         {
             ShouldPrettyPrint = prettyPrint;
             ShouldExcludeNulls = excludeNulls;
             IsJSONP = jsonp;
             UseDateTimeFormat = dateFormat;
             ShouldIncludeInherited = includeInherited;
+            ISO8601ShouldNotConvertToUtc = false;
         }
 
         /// <summary>

--- a/Jil/Serialize/InlineSerializer.cs
+++ b/Jil/Serialize/InlineSerializer.cs
@@ -609,11 +609,14 @@ namespace Jil.Serialize
 
             using (var loc = Emit.DeclareLocal<DateTime>())
             {
-                Emit.StoreLocal(loc);       // TextWriter
-                Emit.LoadLocalAddress(loc); // TextWriter DateTime*
-                Emit.Call(toUniversalTime); // TextWriter DateTime
-                Emit.StoreLocal(loc);       // TextWriter
-                Emit.LoadLocalAddress(loc); // TextWriter DateTime*
+                if (ShouldConvertToUtc)
+                {
+                    Emit.StoreLocal(loc);       // TextWriter
+                    Emit.LoadLocalAddress(loc); // TextWriter DateTime*
+                    Emit.Call(toUniversalTime); // TextWriter DateTime
+                }
+                Emit.StoreLocal(loc);           // TextWriter
+                Emit.LoadLocalAddress(loc);     // TextWriter DateTime*
             }
 
             if (!SkipDateTimeMathMethods)
@@ -667,11 +670,14 @@ namespace Jil.Serialize
 
             using (var loc = Emit.DeclareLocal<DateTime>())
             {
-                Emit.StoreLocal(loc);       // TextWriter
-                Emit.LoadLocalAddress(loc); // TextWriter DateTime*
-                Emit.Call(toUniversalTime); // TextWriter DateTime
-                Emit.StoreLocal(loc);       // TextWriter
-                Emit.LoadLocalAddress(loc); // TextWriter DateTime*
+                if (ShouldConvertToUtc)
+                {
+                    Emit.StoreLocal(loc);       // TextWriter
+                    Emit.LoadLocalAddress(loc); // TextWriter DateTime*
+                    Emit.Call(toUniversalTime); // TextWriter DateTime
+                }
+                Emit.StoreLocal(loc);           // TextWriter
+                Emit.LoadLocalAddress(loc);     // TextWriter DateTime*
             }
 
             if (!SkipDateTimeMathMethods)
@@ -721,11 +727,14 @@ namespace Jil.Serialize
 
             using (var loc = Emit.DeclareLocal<DateTime>())
             {
-                Emit.StoreLocal(loc);       // TextWriter
-                Emit.LoadLocalAddress(loc); // TextWriter DateTime*
-                Emit.Call(toUniversalTime); // TextWriter DateTime
-                Emit.StoreLocal(loc);       // TextWriter
-                Emit.LoadLocalAddress(loc); // TextWriter DateTime*
+                if (ShouldConvertToUtc)
+                {
+                    Emit.StoreLocal(loc);       // TextWriter
+                    Emit.LoadLocalAddress(loc); // TextWriter DateTime*
+                    Emit.Call(toUniversalTime); // TextWriter DateTime
+                }
+                Emit.StoreLocal(loc);           // TextWriter
+                Emit.LoadLocalAddress(loc);     // TextWriter DateTime*
             }
 
             if (!SkipDateTimeMathMethods)
@@ -784,19 +793,14 @@ namespace Jil.Serialize
 
                 using (var loc = Emit.DeclareLocal<DateTime>())
                 {
-                    Emit.StoreLocal(loc);                           // TextWriter
-                    Emit.LoadLocalAddress(loc);                     // TextWriter DateTime*
-                }
-
-                if (ShouldConvertToUtc)
-                {
-                    Emit.Call(toUniversalTime); // TextWriter DateTime
-                }
-
-                using (var loc = Emit.DeclareLocal<DateTime>())
-                {
-                    Emit.StoreLocal(loc);       // TextWriter
-                    Emit.LoadLocalAddress(loc); // TextWriter DateTime*
+                    if (ShouldConvertToUtc)
+                    {
+                        Emit.StoreLocal(loc);       // TextWriter
+                        Emit.LoadLocalAddress(loc); // TextWriter DateTime*
+                        Emit.Call(toUniversalTime); // TextWriter DateTime
+                    }
+                    Emit.StoreLocal(loc);           // TextWriter
+                    Emit.LoadLocalAddress(loc);     // TextWriter DateTime*
                 }
 
                 Emit.LoadConstant("\\\"yyyy-MM-ddTHH:mm:ssZ\\\"");      // TextWriter DateTime* string

--- a/Jil/Serialize/InlineSerializer.cs
+++ b/Jil/Serialize/InlineSerializer.cs
@@ -75,6 +75,7 @@ namespace Jil.Serialize
         private readonly bool JSONP;
         private readonly DateTimeFormat DateFormat;
         private readonly bool IncludeInherited;
+        private readonly bool ISO8601ShouldNotConvertToUtc;
         
         private Dictionary<Type, Sigil.Local> RecursiveTypes;
 
@@ -84,7 +85,7 @@ namespace Jil.Serialize
 
         private readonly bool BuildingToString;
 
-        internal InlineSerializer(Type recursionLookupOptionsType, bool pretty, bool excludeNulls, bool jsonp, DateTimeFormat dateFormat, bool includeInherited, bool callOutOnPossibleDynamic, bool buildToString)
+        internal InlineSerializer(Type recursionLookupOptionsType, bool pretty, bool excludeNulls, bool jsonp, DateTimeFormat dateFormat, bool includeInherited, bool iso8601ShouldNotConvertToUtc, bool callOutOnPossibleDynamic, bool buildToString)
         {
             RecursionLookupOptionsType = recursionLookupOptionsType;
             PrettyPrint = pretty;
@@ -92,6 +93,7 @@ namespace Jil.Serialize
             JSONP = jsonp;
             DateFormat = dateFormat;
             IncludeInherited = includeInherited;
+            ISO8601ShouldNotConvertToUtc = iso8601ShouldNotConvertToUtc;
 
             CallOutOnPossibleDynamic = callOutOnPossibleDynamic;
 
@@ -3655,12 +3657,12 @@ namespace Jil.Serialize
             return emit.CreateDelegate<StringThunkDelegate<BuildForType>>(Utils.DelegateOptimizationOptions);
         }
 
-        public static Action<TextWriter, BuildForType, int> Build<BuildForType>(Type optionsType, bool pretty, bool excludeNulls, bool jsonp, DateTimeFormat dateFormat, bool includeInherited, out Exception exceptionDuringBuild)
+        public static Action<TextWriter, BuildForType, int> Build<BuildForType>(Type optionsType, bool pretty, bool excludeNulls, bool jsonp, DateTimeFormat dateFormat, bool includeInherited, bool iso8601ShouldNotConvertToUtc, out Exception exceptionDuringBuild)
         {
             Action<TextWriter, BuildForType, int> ret;
             try
             {
-                var obj = new InlineSerializer<BuildForType>(optionsType, pretty, excludeNulls, jsonp, dateFormat, includeInherited, false, false);
+                var obj = new InlineSerializer<BuildForType>(optionsType, pretty, excludeNulls, jsonp, dateFormat, includeInherited, iso8601ShouldNotConvertToUtc, false, false);
 
                 ret = obj.Build();
                 exceptionDuringBuild = null;
@@ -3675,18 +3677,18 @@ namespace Jil.Serialize
         }
 
         public static readonly MethodInfo BuildWithDynamism = typeof(InlineSerializerHelper).GetMethod("_BuildWithDynamism", BindingFlags.Static | BindingFlags.NonPublic);
-        private static Action<TextWriter, BuildForType, int> _BuildWithDynamism<BuildForType>(Type optionsType, bool pretty, bool excludeNulls, bool jsonp, DateTimeFormat dateFormat, bool includeInherited)
+        private static Action<TextWriter, BuildForType, int> _BuildWithDynamism<BuildForType>(Type optionsType, bool pretty, bool excludeNulls, bool jsonp, DateTimeFormat dateFormat, bool includeInherited, bool iso8601ShouldNotConvertToUtc)
         {
-            var obj = new InlineSerializer<BuildForType>(optionsType, pretty, excludeNulls, jsonp, dateFormat, includeInherited, true, false);
+            var obj = new InlineSerializer<BuildForType>(optionsType, pretty, excludeNulls, jsonp, dateFormat, includeInherited, iso8601ShouldNotConvertToUtc, true, false);
             return obj.Build();
         }
 
-        public static StringThunkDelegate<BuildForType> BuildToString<BuildForType>(Type optionsType, bool pretty, bool excludeNulls, bool jsonp, DateTimeFormat dateFormat, bool includeInherited, out Exception exceptionDuringBuild)
+        public static StringThunkDelegate<BuildForType> BuildToString<BuildForType>(Type optionsType, bool pretty, bool excludeNulls, bool jsonp, DateTimeFormat dateFormat, bool includeInherited, bool iso8601ShouldNotConvertToUtc, out Exception exceptionDuringBuild)
         {
             StringThunkDelegate<BuildForType> ret;
             try
             {
-                var obj = new InlineSerializer<BuildForType>(optionsType, pretty, excludeNulls, jsonp, dateFormat, includeInherited, false, true);
+                var obj = new InlineSerializer<BuildForType>(optionsType, pretty, excludeNulls, jsonp, dateFormat, includeInherited, iso8601ShouldNotConvertToUtc, false, true);
 
                 ret = obj.BuildToString();
 

--- a/Jil/Serialize/InlineSerializer.cs
+++ b/Jil/Serialize/InlineSerializer.cs
@@ -75,7 +75,7 @@ namespace Jil.Serialize
         private readonly bool JSONP;
         private readonly DateTimeFormat DateFormat;
         private readonly bool IncludeInherited;
-        private readonly bool ISO8601ShouldNotConvertToUtc;
+        private readonly bool ShouldConvertToUtc;
         
         private Dictionary<Type, Sigil.Local> RecursiveTypes;
 
@@ -85,7 +85,7 @@ namespace Jil.Serialize
 
         private readonly bool BuildingToString;
 
-        internal InlineSerializer(Type recursionLookupOptionsType, bool pretty, bool excludeNulls, bool jsonp, DateTimeFormat dateFormat, bool includeInherited, bool iso8601ShouldNotConvertToUtc, bool callOutOnPossibleDynamic, bool buildToString)
+        internal InlineSerializer(Type recursionLookupOptionsType, bool pretty, bool excludeNulls, bool jsonp, DateTimeFormat dateFormat, bool includeInherited, bool shouldConvertToUtc, bool callOutOnPossibleDynamic, bool buildToString)
         {
             RecursionLookupOptionsType = recursionLookupOptionsType;
             PrettyPrint = pretty;
@@ -93,7 +93,7 @@ namespace Jil.Serialize
             JSONP = jsonp;
             DateFormat = dateFormat;
             IncludeInherited = includeInherited;
-            ISO8601ShouldNotConvertToUtc = iso8601ShouldNotConvertToUtc;
+            ShouldConvertToUtc = shouldConvertToUtc;
 
             CallOutOnPossibleDynamic = callOutOnPossibleDynamic;
 
@@ -788,7 +788,7 @@ namespace Jil.Serialize
                     Emit.LoadLocalAddress(loc);                     // TextWriter DateTime*
                 }
 
-                if (!ISO8601ShouldNotConvertToUtc)
+                if (ShouldConvertToUtc)
                 {
                     Emit.Call(toUniversalTime); // TextWriter DateTime
                 }
@@ -800,6 +800,7 @@ namespace Jil.Serialize
                 }
 
                 Emit.LoadConstant("\\\"yyyy-MM-ddTHH:mm:ssZ\\\"");      // TextWriter DateTime* string
+
                 Emit.Call(toString);                                    // TextWriter string
 
                 if (BuildingToString)
@@ -814,7 +815,7 @@ namespace Jil.Serialize
             }
 
             Emit.LoadLocal(CharBuffer);                                     // TextWriter DateTime char[]
-            Emit.LoadConstant(ISO8601ShouldNotConvertToUtc);                // TextWriter DateTime char[] bool
+            Emit.LoadConstant(ShouldConvertToUtc);                // TextWriter DateTime char[] bool
             Emit.Call(Methods.GetCustomISO8601ToString(BuildingToString));  // --empty--
         }
 
@@ -3252,7 +3253,7 @@ namespace Jil.Serialize
                     Emit.LoadConstant(this.JSONP);                        // bool bool bool
                     Emit.LoadConstant((byte)this.DateFormat);             // bool bool bool byte
                     Emit.LoadConstant(this.IncludeInherited);             // bool bool bool DateTimeFormat bool
-                    Emit.LoadConstant(this.ISO8601ShouldNotConvertToUtc); // bool bool bool DateTimeFormat bool
+                    Emit.LoadConstant(this.ShouldConvertToUtc);           // bool bool bool DateTimeFormat bool
                     Emit.Call(getMtd);                                    // Action<TextWriter, type, int>)
                     Emit.StoreLocal(loc);                                 // --empty--
 
@@ -3662,12 +3663,12 @@ namespace Jil.Serialize
             return emit.CreateDelegate<StringThunkDelegate<BuildForType>>(Utils.DelegateOptimizationOptions);
         }
 
-        public static Action<TextWriter, BuildForType, int> Build<BuildForType>(Type optionsType, bool pretty, bool excludeNulls, bool jsonp, DateTimeFormat dateFormat, bool includeInherited, bool iso8601ShouldNotConvertToUtc, out Exception exceptionDuringBuild)
+        public static Action<TextWriter, BuildForType, int> Build<BuildForType>(Type optionsType, bool pretty, bool excludeNulls, bool jsonp, DateTimeFormat dateFormat, bool includeInherited, bool shouldConvertToUtc, out Exception exceptionDuringBuild)
         {
             Action<TextWriter, BuildForType, int> ret;
             try
             {
-                var obj = new InlineSerializer<BuildForType>(optionsType, pretty, excludeNulls, jsonp, dateFormat, includeInherited, iso8601ShouldNotConvertToUtc, false, false);
+                var obj = new InlineSerializer<BuildForType>(optionsType, pretty, excludeNulls, jsonp, dateFormat, includeInherited, shouldConvertToUtc, false, false);
 
                 ret = obj.Build();
                 exceptionDuringBuild = null;
@@ -3688,12 +3689,12 @@ namespace Jil.Serialize
             return obj.Build();
         }
 
-        public static StringThunkDelegate<BuildForType> BuildToString<BuildForType>(Type optionsType, bool pretty, bool excludeNulls, bool jsonp, DateTimeFormat dateFormat, bool includeInherited, bool iso8601ShouldNotConvertToUtc, out Exception exceptionDuringBuild)
+        public static StringThunkDelegate<BuildForType> BuildToString<BuildForType>(Type optionsType, bool pretty, bool excludeNulls, bool jsonp, DateTimeFormat dateFormat, bool includeInherited, bool shouldConvertToUtc, out Exception exceptionDuringBuild)
         {
             StringThunkDelegate<BuildForType> ret;
             try
             {
-                var obj = new InlineSerializer<BuildForType>(optionsType, pretty, excludeNulls, jsonp, dateFormat, includeInherited, iso8601ShouldNotConvertToUtc, false, true);
+                var obj = new InlineSerializer<BuildForType>(optionsType, pretty, excludeNulls, jsonp, dateFormat, includeInherited, shouldConvertToUtc, false, true);
 
                 ret = obj.BuildToString();
 

--- a/Jil/Serialize/InlineSerializer.cs
+++ b/Jil/Serialize/InlineSerializer.cs
@@ -788,7 +788,10 @@ namespace Jil.Serialize
                     Emit.LoadLocalAddress(loc);                     // TextWriter DateTime*
                 }
 
-                Emit.Call(toUniversalTime);                         // TextWriter DateTime
+                if (!ISO8601ShouldNotConvertToUtc)
+                {
+                    Emit.Call(toUniversalTime); // TextWriter DateTime
+                }
 
                 using (var loc = Emit.DeclareLocal<DateTime>())
                 {
@@ -811,6 +814,7 @@ namespace Jil.Serialize
             }
 
             Emit.LoadLocal(CharBuffer);                                     // TextWriter DateTime char[]
+            Emit.LoadConstant(ISO8601ShouldNotConvertToUtc);                // TextWriter DateTime char[] bool
             Emit.Call(Methods.GetCustomISO8601ToString(BuildingToString));  // --empty--
         }
 
@@ -3243,13 +3247,14 @@ namespace Jil.Serialize
                     var getMtd = (MethodInfo)recursiveSerializerCache.GetField("GetFor").GetValue(null);
 
                     var loc = Emit.DeclareLocal(getMtd.ReturnType);
-                    Emit.LoadConstant(this.PrettyPrint);        // bool
-                    Emit.LoadConstant(this.ExcludeNulls);       // bool bool
-                    Emit.LoadConstant(this.JSONP);              // bool bool bool
-                    Emit.LoadConstant((byte)this.DateFormat);   // bool bool bool byte
-                    Emit.LoadConstant(this.IncludeInherited);   // bool bool bool DateTimeFormat bool
-                    Emit.Call(getMtd);                          // Action<TextWriter, type, int>)
-                    Emit.StoreLocal(loc);                       // --empty--
+                    Emit.LoadConstant(this.PrettyPrint);                  // bool
+                    Emit.LoadConstant(this.ExcludeNulls);                 // bool bool
+                    Emit.LoadConstant(this.JSONP);                        // bool bool bool
+                    Emit.LoadConstant((byte)this.DateFormat);             // bool bool bool byte
+                    Emit.LoadConstant(this.IncludeInherited);             // bool bool bool DateTimeFormat bool
+                    Emit.LoadConstant(this.ISO8601ShouldNotConvertToUtc); // bool bool bool DateTimeFormat bool
+                    Emit.Call(getMtd);                                    // Action<TextWriter, type, int>)
+                    Emit.StoreLocal(loc);                                 // --empty--
 
                     ret[type] = loc;
                 }

--- a/Jil/Serialize/Methods.ThunkWriter.cs
+++ b/Jil/Serialize/Methods.ThunkWriter.cs
@@ -137,7 +137,7 @@ namespace Jil.Serialize
 
         static readonly MethodInfo CustomISO8601ToString_ThunkWriter = typeof(Methods).GetMethod("_CustomISO8601ToString_ThunkWriter", BindingFlags.NonPublic | BindingFlags.Static);
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static void _CustomISO8601ToString_ThunkWriter(ref ThunkWriter writer, DateTime dt, char[] buffer)
+        static void _CustomISO8601ToString_ThunkWriter(ref ThunkWriter writer, DateTime dt, char[] buffer, bool shouldNotConvertToUtc)
         {
             // "yyyy-mm-ddThh:mm:ss.fffffffZ"
             // 0123456789ABCDEFGHIJKL
@@ -147,7 +147,8 @@ namespace Jil.Serialize
 
             buffer[0] = '"';
 
-            dt = dt.ToUniversalTime();
+            if(shouldNotConvertToUtc)
+                dt = dt.ToUniversalTime();
 
             uint val;
 
@@ -267,7 +268,10 @@ namespace Jil.Serialize
                 fracEnd = 20;
             }
 
-            buffer[fracEnd] = 'Z';
+            if (!shouldNotConvertToUtc)
+                buffer[fracEnd] = 'Z';
+            else
+                fracEnd = --fracEnd;
             buffer[fracEnd + 1] = '"';
 
             writer.Write(buffer, 0, fracEnd + 2);

--- a/Jil/Serialize/Methods.ThunkWriter.cs
+++ b/Jil/Serialize/Methods.ThunkWriter.cs
@@ -137,7 +137,7 @@ namespace Jil.Serialize
 
         static readonly MethodInfo CustomISO8601ToString_ThunkWriter = typeof(Methods).GetMethod("_CustomISO8601ToString_ThunkWriter", BindingFlags.NonPublic | BindingFlags.Static);
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static void _CustomISO8601ToString_ThunkWriter(ref ThunkWriter writer, DateTime dt, char[] buffer, bool shouldNotConvertToUtc)
+        static void _CustomISO8601ToString_ThunkWriter(ref ThunkWriter writer, DateTime dt, char[] buffer, bool shouldConvertToUtc)
         {
             // "yyyy-mm-ddThh:mm:ss.fffffffZ"
             // 0123456789ABCDEFGHIJKL
@@ -147,8 +147,10 @@ namespace Jil.Serialize
 
             buffer[0] = '"';
 
-            if(shouldNotConvertToUtc)
+            if (shouldConvertToUtc)
+            {
                 dt = dt.ToUniversalTime();
+            }
 
             uint val;
 
@@ -268,10 +270,14 @@ namespace Jil.Serialize
                 fracEnd = 20;
             }
 
-            if (!shouldNotConvertToUtc)
+            if (shouldConvertToUtc)
+            {
                 buffer[fracEnd] = 'Z';
+            }
             else
+            {
                 fracEnd = --fracEnd;
+            }
             buffer[fracEnd + 1] = '"';
 
             writer.Write(buffer, 0, fracEnd + 2);

--- a/Jil/Serialize/Methods.cs
+++ b/Jil/Serialize/Methods.cs
@@ -221,7 +221,7 @@ namespace Jil.Serialize
 
         static readonly MethodInfo CustomISO8601ToString = typeof(Methods).GetMethod("_CustomISO8601ToString", BindingFlags.NonPublic | BindingFlags.Static);
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static void _CustomISO8601ToString(TextWriter writer, DateTime dt, char[] buffer)
+        static void _CustomISO8601ToString(TextWriter writer, DateTime dt, char[] buffer, bool shouldNotConvertToUtc)
         {
             // "yyyy-mm-ddThh:mm:ss.fffffffZ"
             // 0123456789ABCDEFGHIJKL
@@ -231,7 +231,8 @@ namespace Jil.Serialize
 
             buffer[0] = '"';
 
-            dt = dt.ToUniversalTime();
+            if(!shouldNotConvertToUtc)
+                dt = dt.ToUniversalTime();
 
             uint val;
 
@@ -351,7 +352,10 @@ namespace Jil.Serialize
                 fracEnd = 20;
             }
 
-            buffer[fracEnd] = 'Z';
+            if(!shouldNotConvertToUtc)
+                buffer[fracEnd] = 'Z';
+            else
+                fracEnd = --fracEnd;
             buffer[fracEnd + 1] = '"';
 
             writer.Write(buffer, 0, fracEnd + 2);

--- a/Jil/Serialize/Methods.cs
+++ b/Jil/Serialize/Methods.cs
@@ -221,7 +221,7 @@ namespace Jil.Serialize
 
         static readonly MethodInfo CustomISO8601ToString = typeof(Methods).GetMethod("_CustomISO8601ToString", BindingFlags.NonPublic | BindingFlags.Static);
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static void _CustomISO8601ToString(TextWriter writer, DateTime dt, char[] buffer, bool shouldNotConvertToUtc)
+        static void _CustomISO8601ToString(TextWriter writer, DateTime dt, char[] buffer, bool shouldConvertToUtc)
         {
             // "yyyy-mm-ddThh:mm:ss.fffffffZ"
             // 0123456789ABCDEFGHIJKL
@@ -231,8 +231,10 @@ namespace Jil.Serialize
 
             buffer[0] = '"';
 
-            if(!shouldNotConvertToUtc)
+            if (shouldConvertToUtc)
+            {
                 dt = dt.ToUniversalTime();
+            }
 
             uint val;
 
@@ -352,10 +354,14 @@ namespace Jil.Serialize
                 fracEnd = 20;
             }
 
-            if(!shouldNotConvertToUtc)
+            if (shouldConvertToUtc)
+            {
                 buffer[fracEnd] = 'Z';
+            }
             else
+            {
                 fracEnd = --fracEnd;
+            }
             buffer[fracEnd + 1] = '"';
 
             writer.Write(buffer, 0, fracEnd + 2);

--- a/Jil/Serialize/TypeCaches.cs
+++ b/Jil/Serialize/TypeCaches.cs
@@ -17,7 +17,7 @@ namespace Jil.Serialize
         DateTimeFormat DateFormat { get; }
         bool JSONP { get; }
         bool IncludeInherited { get; }
-        bool ISO8601ShouldNotConvertToUtc { get; }
+        bool ShouldConvertToUtc { get; }
     }
 
     static class TypeCache<TOptions, T>
@@ -50,7 +50,7 @@ namespace Jil.Serialize
 
                 var opts = new TOptions();
 
-                Thunk = InlineSerializerHelper.Build<T>(typeof(TOptions), pretty: opts.PrettyPrint, excludeNulls: opts.ExcludeNulls, dateFormat: opts.DateFormat, jsonp: opts.JSONP, includeInherited: opts.IncludeInherited, iso8601ShouldNotConvertToUtc: opts.ISO8601ShouldNotConvertToUtc, exceptionDuringBuild: out ThunkExceptionDuringBuild);
+                Thunk = InlineSerializerHelper.Build<T>(typeof(TOptions), pretty: opts.PrettyPrint, excludeNulls: opts.ExcludeNulls, dateFormat: opts.DateFormat, jsonp: opts.JSONP, includeInherited: opts.IncludeInherited, shouldConvertToUtc: opts.ShouldConvertToUtc, exceptionDuringBuild: out ThunkExceptionDuringBuild);
             }
         }
 
@@ -71,7 +71,7 @@ namespace Jil.Serialize
 
                 var opts = new TOptions();
 
-                StringThunk = InlineSerializerHelper.BuildToString<T>(typeof(TOptions), pretty: opts.PrettyPrint, excludeNulls: opts.ExcludeNulls, dateFormat: opts.DateFormat, jsonp: opts.JSONP, includeInherited: opts.IncludeInherited, iso8601ShouldNotConvertToUtc: opts.ISO8601ShouldNotConvertToUtc, exceptionDuringBuild: out StringThunkExceptionDuringBuild);
+                StringThunk = InlineSerializerHelper.BuildToString<T>(typeof(TOptions), pretty: opts.PrettyPrint, excludeNulls: opts.ExcludeNulls, dateFormat: opts.DateFormat, jsonp: opts.JSONP, includeInherited: opts.IncludeInherited, shouldConvertToUtc: opts.ShouldConvertToUtc, exceptionDuringBuild: out StringThunkExceptionDuringBuild);
             }
         }
     }
@@ -83,7 +83,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class NewtonsoftStyleJSONP : ISerializeOptions
@@ -93,7 +93,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class NewtonsoftStylePrettyPrintExcludeNullsJSONP : ISerializeOptions
@@ -103,7 +103,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class NewtonsoftStylePrettyPrintExcludeNullsJSONPInherited : ISerializeOptions
@@ -113,7 +113,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class NewtonsoftStyleExcludeNullsJSONPInherited : ISerializeOptions
@@ -123,7 +123,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class NewtonsoftStylePrettyPrintJSONPInherited : ISerializeOptions
@@ -133,7 +133,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class NewtonsoftStylePrettyPrintExcludeNullsInherited : ISerializeOptions
@@ -143,7 +143,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class NewtonsoftStyleExcludeNullsInherited : ISerializeOptions
@@ -153,7 +153,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class NewtonsoftStylePrettyPrintInherited : ISerializeOptions
@@ -163,7 +163,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class NewtonsoftStyleJSONPInherited : ISerializeOptions
@@ -173,7 +173,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class NewtonsoftStyleInherited : ISerializeOptions
@@ -183,7 +183,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class NewtonsoftStyleExcludeNullsJSONP : ISerializeOptions
@@ -193,7 +193,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class NewtonsoftStylePrettyPrintJSONP : ISerializeOptions
@@ -203,7 +203,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class NewtonsoftStylePrettyPrint : ISerializeOptions
@@ -213,7 +213,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class NewtonsoftStyleExcludeNulls : ISerializeOptions
@@ -223,7 +223,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class NewtonsoftStylePrettyPrintExcludeNulls : ISerializeOptions
@@ -233,7 +233,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class Milliseconds : ISerializeOptions
@@ -243,7 +243,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class MillisecondsJSONP : ISerializeOptions
@@ -253,7 +253,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class MillisecondsPrettyPrintExcludeNullsJSONP : ISerializeOptions
@@ -263,7 +263,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class MillisecondsPrettyPrintExcludeNullsJSONPInherited : ISerializeOptions
@@ -273,7 +273,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class MillisecondsExcludeNullsJSONPInherited : ISerializeOptions
@@ -283,7 +283,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class MillisecondsPrettyPrintJSONPInherited : ISerializeOptions
@@ -293,7 +293,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class MillisecondsPrettyPrintExcludeNullsInherited : ISerializeOptions
@@ -303,7 +303,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class MillisecondsExcludeNullsInherited : ISerializeOptions
@@ -313,7 +313,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class MillisecondsPrettyPrintInherited : ISerializeOptions
@@ -323,7 +323,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class MillisecondsJSONPInherited : ISerializeOptions
@@ -333,7 +333,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class MillisecondsInherited : ISerializeOptions
@@ -343,7 +343,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class MillisecondsExcludeNullsJSONP : ISerializeOptions
@@ -353,7 +353,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class MillisecondsPrettyPrintJSONP : ISerializeOptions
@@ -363,7 +363,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class MillisecondsPrettyPrint : ISerializeOptions
@@ -373,7 +373,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class MillisecondsExcludeNulls : ISerializeOptions
@@ -383,7 +383,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class MillisecondsPrettyPrintExcludeNulls : ISerializeOptions
@@ -393,7 +393,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class Seconds : ISerializeOptions
@@ -403,7 +403,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class SecondsJSONP : ISerializeOptions
@@ -413,7 +413,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class SecondsPrettyPrintExcludeNullsJSONP : ISerializeOptions
@@ -423,7 +423,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class SecondsPrettyPrintExcludeNullsJSONPInherited : ISerializeOptions
@@ -433,7 +433,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class SecondsExcludeNullsJSONPInherited : ISerializeOptions
@@ -443,7 +443,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class SecondsPrettyPrintJSONPInherited : ISerializeOptions
@@ -453,7 +453,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class SecondsPrettyPrintExcludeNullsInherited : ISerializeOptions
@@ -463,7 +463,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class SecondsExcludeNullsInherited : ISerializeOptions
@@ -473,7 +473,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class SecondsPrettyPrintInherited : ISerializeOptions
@@ -483,7 +483,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class SecondsJSONPInherited : ISerializeOptions
@@ -493,7 +493,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class SecondsInherited : ISerializeOptions
@@ -503,7 +503,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class SecondsExcludeNullsJSONP : ISerializeOptions
@@ -513,7 +513,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class SecondsPrettyPrintJSONP : ISerializeOptions
@@ -523,7 +523,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class SecondsPrettyPrint : ISerializeOptions
@@ -533,7 +533,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class SecondsExcludeNulls : ISerializeOptions
@@ -543,7 +543,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class SecondsPrettyPrintExcludeNulls : ISerializeOptions
@@ -553,7 +553,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class ISO8601 : ISerializeOptions
@@ -563,7 +563,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class ISO8601JSONP : ISerializeOptions
@@ -573,7 +573,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class ISO8601PrettyPrintExcludeNullsJSONP : ISerializeOptions
@@ -583,7 +583,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class ISO8601PrettyPrintExcludeNullsJSONPInherited : ISerializeOptions
@@ -593,7 +593,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class ISO8601ExcludeNullsJSONPInherited : ISerializeOptions
@@ -603,7 +603,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class ISO8601PrettyPrintJSONPInherited : ISerializeOptions
@@ -613,7 +613,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class ISO8601PrettyPrintExcludeNullsInherited : ISerializeOptions
@@ -623,7 +623,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class ISO8601ExcludeNullsInherited : ISerializeOptions
@@ -633,7 +633,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class ISO8601PrettyPrintInherited : ISerializeOptions
@@ -643,7 +643,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class ISO8601JSONPInherited : ISerializeOptions
@@ -653,7 +653,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class ISO8601Inherited : ISerializeOptions
@@ -663,7 +663,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class ISO8601ExcludeNullsJSONP : ISerializeOptions
@@ -673,7 +673,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class ISO8601PrettyPrintJSONP : ISerializeOptions
@@ -683,7 +683,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class ISO8601PrettyPrint : ISerializeOptions
@@ -693,7 +693,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class ISO8601ExcludeNulls : ISerializeOptions
@@ -703,7 +703,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 
     class ISO8601PrettyPrintExcludeNulls : ISerializeOptions
@@ -713,6 +713,6 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
+        public bool ShouldConvertToUtc { get { return true; } }
     }
 }

--- a/Jil/Serialize/TypeCaches.cs
+++ b/Jil/Serialize/TypeCaches.cs
@@ -17,6 +17,7 @@ namespace Jil.Serialize
         DateTimeFormat DateFormat { get; }
         bool JSONP { get; }
         bool IncludeInherited { get; }
+        bool ISO8601ShouldNotConvertToUtc { get; }
     }
 
     static class TypeCache<TOptions, T>
@@ -49,7 +50,7 @@ namespace Jil.Serialize
 
                 var opts = new TOptions();
 
-                Thunk = InlineSerializerHelper.Build<T>(typeof(TOptions), pretty: opts.PrettyPrint, excludeNulls: opts.ExcludeNulls, dateFormat: opts.DateFormat, jsonp: opts.JSONP, includeInherited: opts.IncludeInherited, exceptionDuringBuild: out ThunkExceptionDuringBuild);
+                Thunk = InlineSerializerHelper.Build<T>(typeof(TOptions), pretty: opts.PrettyPrint, excludeNulls: opts.ExcludeNulls, dateFormat: opts.DateFormat, jsonp: opts.JSONP, includeInherited: opts.IncludeInherited, iso8601ShouldNotConvertToUtc: opts.ISO8601ShouldNotConvertToUtc, exceptionDuringBuild: out ThunkExceptionDuringBuild);
             }
         }
 
@@ -70,7 +71,7 @@ namespace Jil.Serialize
 
                 var opts = new TOptions();
 
-                StringThunk = InlineSerializerHelper.BuildToString<T>(typeof(TOptions), pretty: opts.PrettyPrint, excludeNulls: opts.ExcludeNulls, dateFormat: opts.DateFormat, jsonp: opts.JSONP, includeInherited: opts.IncludeInherited, exceptionDuringBuild: out StringThunkExceptionDuringBuild);
+                StringThunk = InlineSerializerHelper.BuildToString<T>(typeof(TOptions), pretty: opts.PrettyPrint, excludeNulls: opts.ExcludeNulls, dateFormat: opts.DateFormat, jsonp: opts.JSONP, includeInherited: opts.IncludeInherited, iso8601ShouldNotConvertToUtc: opts.ISO8601ShouldNotConvertToUtc, exceptionDuringBuild: out StringThunkExceptionDuringBuild);
             }
         }
     }
@@ -82,6 +83,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class NewtonsoftStyleJSONP : ISerializeOptions
@@ -91,6 +93,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class NewtonsoftStylePrettyPrintExcludeNullsJSONP : ISerializeOptions
@@ -100,6 +103,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class NewtonsoftStylePrettyPrintExcludeNullsJSONPInherited : ISerializeOptions
@@ -109,6 +113,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class NewtonsoftStyleExcludeNullsJSONPInherited : ISerializeOptions
@@ -118,6 +123,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class NewtonsoftStylePrettyPrintJSONPInherited : ISerializeOptions
@@ -127,6 +133,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class NewtonsoftStylePrettyPrintExcludeNullsInherited : ISerializeOptions
@@ -136,6 +143,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class NewtonsoftStyleExcludeNullsInherited : ISerializeOptions
@@ -145,6 +153,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class NewtonsoftStylePrettyPrintInherited : ISerializeOptions
@@ -154,6 +163,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class NewtonsoftStyleJSONPInherited : ISerializeOptions
@@ -163,6 +173,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class NewtonsoftStyleInherited : ISerializeOptions
@@ -172,6 +183,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class NewtonsoftStyleExcludeNullsJSONP : ISerializeOptions
@@ -181,6 +193,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class NewtonsoftStylePrettyPrintJSONP : ISerializeOptions
@@ -190,6 +203,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class NewtonsoftStylePrettyPrint : ISerializeOptions
@@ -199,6 +213,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class NewtonsoftStyleExcludeNulls : ISerializeOptions
@@ -208,6 +223,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class NewtonsoftStylePrettyPrintExcludeNulls : ISerializeOptions
@@ -217,6 +233,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class Milliseconds : ISerializeOptions
@@ -226,6 +243,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class MillisecondsJSONP : ISerializeOptions
@@ -235,6 +253,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class MillisecondsPrettyPrintExcludeNullsJSONP : ISerializeOptions
@@ -244,6 +263,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class MillisecondsPrettyPrintExcludeNullsJSONPInherited : ISerializeOptions
@@ -253,6 +273,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class MillisecondsExcludeNullsJSONPInherited : ISerializeOptions
@@ -262,6 +283,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class MillisecondsPrettyPrintJSONPInherited : ISerializeOptions
@@ -271,6 +293,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class MillisecondsPrettyPrintExcludeNullsInherited : ISerializeOptions
@@ -280,6 +303,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class MillisecondsExcludeNullsInherited : ISerializeOptions
@@ -289,6 +313,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class MillisecondsPrettyPrintInherited : ISerializeOptions
@@ -298,6 +323,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class MillisecondsJSONPInherited : ISerializeOptions
@@ -307,6 +333,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class MillisecondsInherited : ISerializeOptions
@@ -316,6 +343,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class MillisecondsExcludeNullsJSONP : ISerializeOptions
@@ -325,6 +353,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class MillisecondsPrettyPrintJSONP : ISerializeOptions
@@ -334,6 +363,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class MillisecondsPrettyPrint : ISerializeOptions
@@ -343,6 +373,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class MillisecondsExcludeNulls : ISerializeOptions
@@ -352,6 +383,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class MillisecondsPrettyPrintExcludeNulls : ISerializeOptions
@@ -361,6 +393,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class Seconds : ISerializeOptions
@@ -370,6 +403,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class SecondsJSONP : ISerializeOptions
@@ -379,6 +413,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class SecondsPrettyPrintExcludeNullsJSONP : ISerializeOptions
@@ -388,6 +423,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class SecondsPrettyPrintExcludeNullsJSONPInherited : ISerializeOptions
@@ -397,6 +433,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class SecondsExcludeNullsJSONPInherited : ISerializeOptions
@@ -406,6 +443,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class SecondsPrettyPrintJSONPInherited : ISerializeOptions
@@ -415,6 +453,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class SecondsPrettyPrintExcludeNullsInherited : ISerializeOptions
@@ -424,6 +463,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class SecondsExcludeNullsInherited : ISerializeOptions
@@ -433,6 +473,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class SecondsPrettyPrintInherited : ISerializeOptions
@@ -442,6 +483,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class SecondsJSONPInherited : ISerializeOptions
@@ -451,6 +493,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class SecondsInherited : ISerializeOptions
@@ -460,6 +503,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class SecondsExcludeNullsJSONP : ISerializeOptions
@@ -469,6 +513,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class SecondsPrettyPrintJSONP : ISerializeOptions
@@ -478,6 +523,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class SecondsPrettyPrint : ISerializeOptions
@@ -487,6 +533,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class SecondsExcludeNulls : ISerializeOptions
@@ -496,6 +543,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class SecondsPrettyPrintExcludeNulls : ISerializeOptions
@@ -505,6 +553,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class ISO8601 : ISerializeOptions
@@ -514,6 +563,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class ISO8601JSONP : ISerializeOptions
@@ -523,6 +573,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class ISO8601PrettyPrintExcludeNullsJSONP : ISerializeOptions
@@ -532,6 +583,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class ISO8601PrettyPrintExcludeNullsJSONPInherited : ISerializeOptions
@@ -541,6 +593,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class ISO8601ExcludeNullsJSONPInherited : ISerializeOptions
@@ -550,6 +603,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class ISO8601PrettyPrintJSONPInherited : ISerializeOptions
@@ -559,6 +613,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class ISO8601PrettyPrintExcludeNullsInherited : ISerializeOptions
@@ -568,6 +623,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class ISO8601ExcludeNullsInherited : ISerializeOptions
@@ -577,6 +633,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class ISO8601PrettyPrintInherited : ISerializeOptions
@@ -586,6 +643,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class ISO8601JSONPInherited : ISerializeOptions
@@ -595,6 +653,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class ISO8601Inherited : ISerializeOptions
@@ -604,6 +663,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class ISO8601ExcludeNullsJSONP : ISerializeOptions
@@ -613,6 +673,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class ISO8601PrettyPrintJSONP : ISerializeOptions
@@ -622,6 +683,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class ISO8601PrettyPrint : ISerializeOptions
@@ -631,6 +693,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class ISO8601ExcludeNulls : ISerializeOptions
@@ -640,6 +703,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 
     class ISO8601PrettyPrintExcludeNulls : ISerializeOptions
@@ -649,5 +713,6 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
+        public bool ISO8601ShouldNotConvertToUtc { get { return false; } }
     }
 }

--- a/Jil/Serialize/TypeCaches.cs
+++ b/Jil/Serialize/TypeCaches.cs
@@ -17,7 +17,7 @@ namespace Jil.Serialize
         DateTimeFormat DateFormat { get; }
         bool JSONP { get; }
         bool IncludeInherited { get; }
-        bool ShouldConvertToUtc { get; }
+        bool ConvertToUtc { get; }
     }
 
     static class TypeCache<TOptions, T>
@@ -50,7 +50,7 @@ namespace Jil.Serialize
 
                 var opts = new TOptions();
 
-                Thunk = InlineSerializerHelper.Build<T>(typeof(TOptions), pretty: opts.PrettyPrint, excludeNulls: opts.ExcludeNulls, dateFormat: opts.DateFormat, jsonp: opts.JSONP, includeInherited: opts.IncludeInherited, shouldConvertToUtc: opts.ShouldConvertToUtc, exceptionDuringBuild: out ThunkExceptionDuringBuild);
+                Thunk = InlineSerializerHelper.Build<T>(typeof(TOptions), pretty: opts.PrettyPrint, excludeNulls: opts.ExcludeNulls, dateFormat: opts.DateFormat, jsonp: opts.JSONP, includeInherited: opts.IncludeInherited, shouldConvertToUtc: opts.ConvertToUtc, exceptionDuringBuild: out ThunkExceptionDuringBuild);
             }
         }
 
@@ -71,7 +71,7 @@ namespace Jil.Serialize
 
                 var opts = new TOptions();
 
-                StringThunk = InlineSerializerHelper.BuildToString<T>(typeof(TOptions), pretty: opts.PrettyPrint, excludeNulls: opts.ExcludeNulls, dateFormat: opts.DateFormat, jsonp: opts.JSONP, includeInherited: opts.IncludeInherited, shouldConvertToUtc: opts.ShouldConvertToUtc, exceptionDuringBuild: out StringThunkExceptionDuringBuild);
+                StringThunk = InlineSerializerHelper.BuildToString<T>(typeof(TOptions), pretty: opts.PrettyPrint, excludeNulls: opts.ExcludeNulls, dateFormat: opts.DateFormat, jsonp: opts.JSONP, includeInherited: opts.IncludeInherited, shouldConvertToUtc: opts.ConvertToUtc, exceptionDuringBuild: out StringThunkExceptionDuringBuild);
             }
         }
     }
@@ -83,7 +83,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class NewtonsoftStyleJSONP : ISerializeOptions
@@ -93,7 +93,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class NewtonsoftStylePrettyPrintExcludeNullsJSONP : ISerializeOptions
@@ -103,7 +103,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class NewtonsoftStylePrettyPrintExcludeNullsJSONPInherited : ISerializeOptions
@@ -113,7 +113,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class NewtonsoftStyleExcludeNullsJSONPInherited : ISerializeOptions
@@ -123,7 +123,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class NewtonsoftStylePrettyPrintJSONPInherited : ISerializeOptions
@@ -133,7 +133,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class NewtonsoftStylePrettyPrintExcludeNullsInherited : ISerializeOptions
@@ -143,7 +143,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class NewtonsoftStyleExcludeNullsInherited : ISerializeOptions
@@ -153,7 +153,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class NewtonsoftStylePrettyPrintInherited : ISerializeOptions
@@ -163,7 +163,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class NewtonsoftStyleJSONPInherited : ISerializeOptions
@@ -173,7 +173,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class NewtonsoftStyleInherited : ISerializeOptions
@@ -183,7 +183,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class NewtonsoftStyleExcludeNullsJSONP : ISerializeOptions
@@ -193,7 +193,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class NewtonsoftStylePrettyPrintJSONP : ISerializeOptions
@@ -203,7 +203,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class NewtonsoftStylePrettyPrint : ISerializeOptions
@@ -213,7 +213,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class NewtonsoftStyleExcludeNulls : ISerializeOptions
@@ -223,7 +223,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class NewtonsoftStylePrettyPrintExcludeNulls : ISerializeOptions
@@ -233,7 +233,167 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
+    }
+
+    class NewtonsoftStyleNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return false; } }
+        public bool ExcludeNulls { get { return false; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return false; } }
+        public bool IncludeInherited { get { return false; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class NewtonsoftStyleJSONPNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return false; } }
+        public bool ExcludeNulls { get { return false; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return true; } }
+        public bool IncludeInherited { get { return false; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class NewtonsoftStylePrettyPrintExcludeNullsJSONPNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return true; } }
+        public bool ExcludeNulls { get { return true; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return true; } }
+        public bool IncludeInherited { get { return false; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class NewtonsoftStylePrettyPrintExcludeNullsJSONPInheritedNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return true; } }
+        public bool ExcludeNulls { get { return true; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return true; } }
+        public bool IncludeInherited { get { return true; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class NewtonsoftStyleExcludeNullsJSONPInheritedNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return false; } }
+        public bool ExcludeNulls { get { return true; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return true; } }
+        public bool IncludeInherited { get { return true; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class NewtonsoftStylePrettyPrintJSONPInheritedNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return true; } }
+        public bool ExcludeNulls { get { return false; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return true; } }
+        public bool IncludeInherited { get { return true; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class NewtonsoftStylePrettyPrintExcludeNullsInheritedNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return true; } }
+        public bool ExcludeNulls { get { return true; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return false; } }
+        public bool IncludeInherited { get { return true; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class NewtonsoftStyleExcludeNullsInheritedNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return false; } }
+        public bool ExcludeNulls { get { return true; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return false; } }
+        public bool IncludeInherited { get { return true; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class NewtonsoftStylePrettyPrintInheritedNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return true; } }
+        public bool ExcludeNulls { get { return false; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return false; } }
+        public bool IncludeInherited { get { return true; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class NewtonsoftStyleJSONPInheritedNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return false; } }
+        public bool ExcludeNulls { get { return false; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return true; } }
+        public bool IncludeInherited { get { return true; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class NewtonsoftStyleInheritedNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return false; } }
+        public bool ExcludeNulls { get { return false; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return false; } }
+        public bool IncludeInherited { get { return true; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class NewtonsoftStyleExcludeNullsJSONPNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return false; } }
+        public bool ExcludeNulls { get { return true; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return true; } }
+        public bool IncludeInherited { get { return false; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class NewtonsoftStylePrettyPrintJSONPNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return true; } }
+        public bool ExcludeNulls { get { return false; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return true; } }
+        public bool IncludeInherited { get { return false; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class NewtonsoftStylePrettyPrintNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return true; } }
+        public bool ExcludeNulls { get { return false; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return false; } }
+        public bool IncludeInherited { get { return false; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class NewtonsoftStyleExcludeNullsNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return false; } }
+        public bool ExcludeNulls { get { return true; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return false; } }
+        public bool IncludeInherited { get { return false; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class NewtonsoftStylePrettyPrintExcludeNullsNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return true; } }
+        public bool ExcludeNulls { get { return true; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.NewtonsoftStyleMillisecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return false; } }
+        public bool IncludeInherited { get { return false; } }
+        public bool ConvertToUtc { get { return false; } }
     }
 
     class Milliseconds : ISerializeOptions
@@ -243,7 +403,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class MillisecondsJSONP : ISerializeOptions
@@ -253,7 +413,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class MillisecondsPrettyPrintExcludeNullsJSONP : ISerializeOptions
@@ -263,7 +423,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class MillisecondsPrettyPrintExcludeNullsJSONPInherited : ISerializeOptions
@@ -273,7 +433,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class MillisecondsExcludeNullsJSONPInherited : ISerializeOptions
@@ -283,7 +443,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class MillisecondsPrettyPrintJSONPInherited : ISerializeOptions
@@ -293,7 +453,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class MillisecondsPrettyPrintExcludeNullsInherited : ISerializeOptions
@@ -303,7 +463,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class MillisecondsExcludeNullsInherited : ISerializeOptions
@@ -313,7 +473,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class MillisecondsPrettyPrintInherited : ISerializeOptions
@@ -323,7 +483,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class MillisecondsJSONPInherited : ISerializeOptions
@@ -333,7 +493,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class MillisecondsInherited : ISerializeOptions
@@ -343,7 +503,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class MillisecondsExcludeNullsJSONP : ISerializeOptions
@@ -353,7 +513,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class MillisecondsPrettyPrintJSONP : ISerializeOptions
@@ -363,7 +523,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class MillisecondsPrettyPrint : ISerializeOptions
@@ -373,7 +533,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class MillisecondsExcludeNulls : ISerializeOptions
@@ -383,7 +543,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class MillisecondsPrettyPrintExcludeNulls : ISerializeOptions
@@ -393,7 +553,167 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
+    }
+
+    class MillisecondsNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return false; } }
+        public bool ExcludeNulls { get { return false; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return false; } }
+        public bool IncludeInherited { get { return false; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class MillisecondsJSONPNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return false; } }
+        public bool ExcludeNulls { get { return false; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return true; } }
+        public bool IncludeInherited { get { return false; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class MillisecondsPrettyPrintExcludeNullsJSONPNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return true; } }
+        public bool ExcludeNulls { get { return true; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return true; } }
+        public bool IncludeInherited { get { return false; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class MillisecondsPrettyPrintExcludeNullsJSONPInheritedNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return true; } }
+        public bool ExcludeNulls { get { return true; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return true; } }
+        public bool IncludeInherited { get { return true; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class MillisecondsExcludeNullsJSONPInheritedNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return false; } }
+        public bool ExcludeNulls { get { return true; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return true; } }
+        public bool IncludeInherited { get { return true; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class MillisecondsPrettyPrintJSONPInheritedNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return true; } }
+        public bool ExcludeNulls { get { return false; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return true; } }
+        public bool IncludeInherited { get { return true; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class MillisecondsPrettyPrintExcludeNullsInheritedNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return true; } }
+        public bool ExcludeNulls { get { return true; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return false; } }
+        public bool IncludeInherited { get { return true; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class MillisecondsExcludeNullsInheritedNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return false; } }
+        public bool ExcludeNulls { get { return true; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return false; } }
+        public bool IncludeInherited { get { return true; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class MillisecondsPrettyPrintInheritedNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return true; } }
+        public bool ExcludeNulls { get { return false; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return false; } }
+        public bool IncludeInherited { get { return true; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class MillisecondsJSONPInheritedNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return false; } }
+        public bool ExcludeNulls { get { return false; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return true; } }
+        public bool IncludeInherited { get { return true; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class MillisecondsInheritedNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return false; } }
+        public bool ExcludeNulls { get { return false; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return false; } }
+        public bool IncludeInherited { get { return true; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class MillisecondsExcludeNullsJSONPNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return false; } }
+        public bool ExcludeNulls { get { return true; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return true; } }
+        public bool IncludeInherited { get { return false; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class MillisecondsPrettyPrintJSONPNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return true; } }
+        public bool ExcludeNulls { get { return false; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return true; } }
+        public bool IncludeInherited { get { return false; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class MillisecondsPrettyPrintNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return true; } }
+        public bool ExcludeNulls { get { return false; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return false; } }
+        public bool IncludeInherited { get { return false; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class MillisecondsExcludeNullsNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return false; } }
+        public bool ExcludeNulls { get { return true; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return false; } }
+        public bool IncludeInherited { get { return false; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class MillisecondsPrettyPrintExcludeNullsNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return true; } }
+        public bool ExcludeNulls { get { return true; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.MillisecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return false; } }
+        public bool IncludeInherited { get { return false; } }
+        public bool ConvertToUtc { get { return false; } }
     }
 
     class Seconds : ISerializeOptions
@@ -403,7 +723,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class SecondsJSONP : ISerializeOptions
@@ -413,7 +733,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class SecondsPrettyPrintExcludeNullsJSONP : ISerializeOptions
@@ -423,7 +743,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class SecondsPrettyPrintExcludeNullsJSONPInherited : ISerializeOptions
@@ -433,7 +753,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class SecondsExcludeNullsJSONPInherited : ISerializeOptions
@@ -443,7 +763,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class SecondsPrettyPrintJSONPInherited : ISerializeOptions
@@ -453,7 +773,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class SecondsPrettyPrintExcludeNullsInherited : ISerializeOptions
@@ -463,7 +783,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class SecondsExcludeNullsInherited : ISerializeOptions
@@ -473,7 +793,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class SecondsPrettyPrintInherited : ISerializeOptions
@@ -483,7 +803,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class SecondsJSONPInherited : ISerializeOptions
@@ -493,7 +813,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class SecondsInherited : ISerializeOptions
@@ -503,7 +823,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class SecondsExcludeNullsJSONP : ISerializeOptions
@@ -513,7 +833,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class SecondsPrettyPrintJSONP : ISerializeOptions
@@ -523,7 +843,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class SecondsPrettyPrint : ISerializeOptions
@@ -533,7 +853,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class SecondsExcludeNulls : ISerializeOptions
@@ -543,7 +863,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class SecondsPrettyPrintExcludeNulls : ISerializeOptions
@@ -553,7 +873,167 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
+    }
+
+    class SecondsNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return false; } }
+        public bool ExcludeNulls { get { return false; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return false; } }
+        public bool IncludeInherited { get { return false; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class SecondsJSONPNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return false; } }
+        public bool ExcludeNulls { get { return false; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return true; } }
+        public bool IncludeInherited { get { return false; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class SecondsPrettyPrintExcludeNullsJSONPNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return true; } }
+        public bool ExcludeNulls { get { return true; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return true; } }
+        public bool IncludeInherited { get { return false; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class SecondsPrettyPrintExcludeNullsJSONPInheritedNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return true; } }
+        public bool ExcludeNulls { get { return true; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return true; } }
+        public bool IncludeInherited { get { return true; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class SecondsExcludeNullsJSONPInheritedNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return false; } }
+        public bool ExcludeNulls { get { return true; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return true; } }
+        public bool IncludeInherited { get { return true; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class SecondsPrettyPrintJSONPInheritedNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return true; } }
+        public bool ExcludeNulls { get { return false; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return true; } }
+        public bool IncludeInherited { get { return true; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class SecondsPrettyPrintExcludeNullsInheritedNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return true; } }
+        public bool ExcludeNulls { get { return true; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return false; } }
+        public bool IncludeInherited { get { return true; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class SecondsExcludeNullsInheritedNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return false; } }
+        public bool ExcludeNulls { get { return true; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return false; } }
+        public bool IncludeInherited { get { return true; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class SecondsPrettyPrintInheritedNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return true; } }
+        public bool ExcludeNulls { get { return false; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return false; } }
+        public bool IncludeInherited { get { return true; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class SecondsJSONPInheritedNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return false; } }
+        public bool ExcludeNulls { get { return false; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return true; } }
+        public bool IncludeInherited { get { return true; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class SecondsInheritedNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return false; } }
+        public bool ExcludeNulls { get { return false; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return false; } }
+        public bool IncludeInherited { get { return true; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class SecondsExcludeNullsJSONPNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return false; } }
+        public bool ExcludeNulls { get { return true; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return true; } }
+        public bool IncludeInherited { get { return false; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class SecondsPrettyPrintJSONPNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return true; } }
+        public bool ExcludeNulls { get { return false; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return true; } }
+        public bool IncludeInherited { get { return false; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class SecondsPrettyPrintNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return true; } }
+        public bool ExcludeNulls { get { return false; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return false; } }
+        public bool IncludeInherited { get { return false; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class SecondsExcludeNullsNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return false; } }
+        public bool ExcludeNulls { get { return true; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return false; } }
+        public bool IncludeInherited { get { return false; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class SecondsPrettyPrintExcludeNullsNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return true; } }
+        public bool ExcludeNulls { get { return true; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.SecondsSinceUnixEpoch; } }
+        public bool JSONP { get { return false; } }
+        public bool IncludeInherited { get { return false; } }
+        public bool ConvertToUtc { get { return false; } }
     }
 
     class ISO8601 : ISerializeOptions
@@ -563,7 +1043,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class ISO8601JSONP : ISerializeOptions
@@ -573,7 +1053,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class ISO8601PrettyPrintExcludeNullsJSONP : ISerializeOptions
@@ -583,7 +1063,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class ISO8601PrettyPrintExcludeNullsJSONPInherited : ISerializeOptions
@@ -593,7 +1073,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class ISO8601ExcludeNullsJSONPInherited : ISerializeOptions
@@ -603,7 +1083,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class ISO8601PrettyPrintJSONPInherited : ISerializeOptions
@@ -613,7 +1093,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class ISO8601PrettyPrintExcludeNullsInherited : ISerializeOptions
@@ -623,7 +1103,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class ISO8601ExcludeNullsInherited : ISerializeOptions
@@ -633,7 +1113,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class ISO8601PrettyPrintInherited : ISerializeOptions
@@ -643,7 +1123,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class ISO8601JSONPInherited : ISerializeOptions
@@ -653,7 +1133,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class ISO8601Inherited : ISerializeOptions
@@ -663,7 +1143,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return true; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class ISO8601ExcludeNullsJSONP : ISerializeOptions
@@ -673,7 +1153,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class ISO8601PrettyPrintJSONP : ISerializeOptions
@@ -683,7 +1163,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return true; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class ISO8601PrettyPrint : ISerializeOptions
@@ -693,7 +1173,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class ISO8601ExcludeNulls : ISerializeOptions
@@ -703,7 +1183,7 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
     }
 
     class ISO8601PrettyPrintExcludeNulls : ISerializeOptions
@@ -713,6 +1193,166 @@ namespace Jil.Serialize
         public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
         public bool JSONP { get { return false; } }
         public bool IncludeInherited { get { return false; } }
-        public bool ShouldConvertToUtc { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
+    }
+
+    class ISO8601NotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return false; } }
+        public bool ExcludeNulls { get { return false; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
+        public bool JSONP { get { return false; } }
+        public bool IncludeInherited { get { return false; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class ISO8601JSONPNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return false; } }
+        public bool ExcludeNulls { get { return false; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
+        public bool JSONP { get { return true; } }
+        public bool IncludeInherited { get { return false; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class ISO8601PrettyPrintExcludeNullsJSONPNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return true; } }
+        public bool ExcludeNulls { get { return true; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
+        public bool JSONP { get { return true; } }
+        public bool IncludeInherited { get { return false; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class ISO8601PrettyPrintExcludeNullsJSONPInheritedNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return true; } }
+        public bool ExcludeNulls { get { return true; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
+        public bool JSONP { get { return true; } }
+        public bool IncludeInherited { get { return true; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class ISO8601ExcludeNullsJSONPInheritedNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return false; } }
+        public bool ExcludeNulls { get { return true; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
+        public bool JSONP { get { return true; } }
+        public bool IncludeInherited { get { return true; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class ISO8601PrettyPrintJSONPInheritedNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return true; } }
+        public bool ExcludeNulls { get { return false; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
+        public bool JSONP { get { return true; } }
+        public bool IncludeInherited { get { return true; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class ISO8601PrettyPrintExcludeNullsInheritedNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return true; } }
+        public bool ExcludeNulls { get { return true; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
+        public bool JSONP { get { return false; } }
+        public bool IncludeInherited { get { return true; } }
+        public bool ConvertToUtc { get { return true; } }
+    }
+
+    class ISO8601ExcludeNullsInheritedNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return false; } }
+        public bool ExcludeNulls { get { return true; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
+        public bool JSONP { get { return false; } }
+        public bool IncludeInherited { get { return true; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class ISO8601PrettyPrintInheritedNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return true; } }
+        public bool ExcludeNulls { get { return false; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
+        public bool JSONP { get { return false; } }
+        public bool IncludeInherited { get { return true; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class ISO8601JSONPInheritedNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return false; } }
+        public bool ExcludeNulls { get { return false; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
+        public bool JSONP { get { return true; } }
+        public bool IncludeInherited { get { return true; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class ISO8601InheritedNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return false; } }
+        public bool ExcludeNulls { get { return false; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
+        public bool JSONP { get { return false; } }
+        public bool IncludeInherited { get { return true; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class ISO8601ExcludeNullsJSONPNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return false; } }
+        public bool ExcludeNulls { get { return true; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
+        public bool JSONP { get { return true; } }
+        public bool IncludeInherited { get { return false; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class ISO8601PrettyPrintJSONPNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return true; } }
+        public bool ExcludeNulls { get { return false; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
+        public bool JSONP { get { return true; } }
+        public bool IncludeInherited { get { return false; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class ISO8601PrettyPrintNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return true; } }
+        public bool ExcludeNulls { get { return false; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
+        public bool JSONP { get { return false; } }
+        public bool IncludeInherited { get { return false; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class ISO8601ExcludeNullsNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return false; } }
+        public bool ExcludeNulls { get { return true; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
+        public bool JSONP { get { return false; } }
+        public bool IncludeInherited { get { return false; } }
+        public bool ConvertToUtc { get { return false; } }
+    }
+
+    class ISO8601PrettyPrintExcludeNullsNotConvertToUtc : ISerializeOptions
+    {
+        public bool PrettyPrint { get { return true; } }
+        public bool ExcludeNulls { get { return true; } }
+        public DateTimeFormat DateFormat { get { return DateTimeFormat.ISO8601; } }
+        public bool JSONP { get { return false; } }
+        public bool IncludeInherited { get { return false; } }
+        public bool ConvertToUtc { get { return false; } }
     }
 }

--- a/Jil/SerializeDynamic/DynamicSerializer.cs
+++ b/Jil/SerializeDynamic/DynamicSerializer.cs
@@ -169,7 +169,7 @@ namespace Jil.SerializeDynamic
             {
                 ret = (Action<TextWriter, ForType, int>)GetSemiStaticInlineSerializerForCache[key];
                 if (ret != null) return ret;
-                GetSemiStaticInlineSerializerForCache[key] = ret = (Action<TextWriter, ForType, int>)builder.Invoke(null, new object[] { cacheType, opts.ShouldPrettyPrint, opts.ShouldExcludeNulls, opts.IsJSONP, opts.UseDateTimeFormat, opts.ShouldIncludeInherited });
+                GetSemiStaticInlineSerializerForCache[key] = ret = (Action<TextWriter, ForType, int>)builder.Invoke(null, new object[] { cacheType, opts.ShouldPrettyPrint, opts.ShouldExcludeNulls, opts.IsJSONP, opts.UseDateTimeFormat, opts.ShouldIncludeInherited, opts.ISO8601ShouldNotConvertToUtc });
             }
 
             return ret;

--- a/Jil/SerializeDynamic/DynamicSerializer.cs
+++ b/Jil/SerializeDynamic/DynamicSerializer.cs
@@ -169,7 +169,7 @@ namespace Jil.SerializeDynamic
             {
                 ret = (Action<TextWriter, ForType, int>)GetSemiStaticInlineSerializerForCache[key];
                 if (ret != null) return ret;
-                GetSemiStaticInlineSerializerForCache[key] = ret = (Action<TextWriter, ForType, int>)builder.Invoke(null, new object[] { cacheType, opts.ShouldPrettyPrint, opts.ShouldExcludeNulls, opts.IsJSONP, opts.UseDateTimeFormat, opts.ShouldIncludeInherited, opts.ISO8601ShouldNotConvertToUtc });
+                GetSemiStaticInlineSerializerForCache[key] = ret = (Action<TextWriter, ForType, int>)builder.Invoke(null, new object[] { cacheType, opts.ShouldPrettyPrint, opts.ShouldExcludeNulls, opts.IsJSONP, opts.UseDateTimeFormat, opts.ShouldIncludeInherited, opts.ShouldConvertToUtc });
             }
 
             return ret;

--- a/JilTests/SerializeTests.cs
+++ b/JilTests/SerializeTests.cs
@@ -11,6 +11,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
+using DateTimeFormat = Jil.DateTimeFormat;
 
 namespace JilTests
 {
@@ -1600,6 +1601,58 @@ namespace JilTests
                 }
 
                 Assert.AreEqual(expected, actual);
+            }
+        }
+
+        [TestMethod]
+        public void DateTimeWithoutUtcConvertion()
+        {
+            using (var str = new StringWriter())
+            {
+                JSON.Serialize(
+                    new DateTime(1980, 1, 1, 0, 0, 0, DateTimeKind.Unspecified),
+                    str,
+                    new Options(shouldConvertToUtc: false)
+                );
+
+                var res = str.ToString();
+                Assert.AreEqual("\"\\/Date(315532800000)\\/\"", res);
+            }
+
+            using (var str = new StringWriter())
+            {
+                JSON.Serialize(
+                    new DateTime(1980, 1, 1, 0, 0, 0, DateTimeKind.Unspecified),
+                    str,
+                    new Options(dateFormat: DateTimeFormat.MillisecondsSinceUnixEpoch, shouldConvertToUtc: false)
+                );
+
+                var res = str.ToString();
+                Assert.AreEqual("315532800000", res);
+            }
+
+            using (var str = new StringWriter())
+            {
+                JSON.Serialize(
+                    new DateTime(1980, 1, 1, 0, 0, 0, DateTimeKind.Unspecified),
+                    str,
+                    new Options(dateFormat: DateTimeFormat.SecondsSinceUnixEpoch, shouldConvertToUtc: false)
+                );
+
+                var res = str.ToString();
+                Assert.AreEqual("315532800", res);
+            }
+
+            using (var str = new StringWriter())
+            {
+                JSON.Serialize(
+                    new DateTime(1980, 1, 1, 0, 0, 0, DateTimeKind.Unspecified),
+                    str,
+                    new Options(dateFormat: DateTimeFormat.ISO8601, shouldConvertToUtc: false)
+                );
+
+                var res = str.ToString();
+                Assert.AreEqual("\"1980-01-01T00:00:00\"", res);
             }
         }
 


### PR DESCRIPTION
This PR include an option for disabling conversion to UTC in the serialization methods. The reason for this is the wrongly date serialization when the DateTime Kind property is set to unspecific. In that case the method `ToUniversalTime ` decide that the date is in local time representation and convert it based on the local time zone which may lead to wrong date in the end.