### PR TITLE
Removed left over Newtonsoft references in comments

### DIFF
--- a/Jil/Deserialize/Methods.ReadNumbers.cs
+++ b/Jil/Deserialize/Methods.ReadNumbers.cs
@@ -23,11 +23,12 @@ namespace Jil.Deserialize
     //      * *except* for long, where we accumulate into a ulong and do the special checked; because there's no larger type
     static partial class Methods
     {
+        // Note: This same method, but then for ThunkReader, is in Methods.ThunkReader.cs; it's called "_DiscardMicrosoftTimeZoneOffsetThunkReader".
         static readonly MethodInfo DiscardMicrosoftTimeZoneOffset = typeof(Methods).GetMethod("_DiscardMicrosoftTimeZoneOffset", BindingFlags.Static | BindingFlags.NonPublic);
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static void _DiscardMicrosoftTimeZoneOffset(TextReader reader)
         {
-            // this is a special case when reading timezone information for NewtsonsoftStyle DateTimes
+            // this is a special case when reading timezone information for MicrosoftStyle DateTimes
             //   so far as I can tell this is pointless data, the millisecond offset is still UTC relative
             //   so just use that... should validate that this correct though
             // max +9999

--- a/Jil/Deserialize/Methods.ThunkReader.cs
+++ b/Jil/Deserialize/Methods.ThunkReader.cs
@@ -3112,11 +3112,12 @@ namespace Jil.Deserialize
             SkipEncodedStringWithLeadCharThunkReader(ref reader, reader.Read());
         }
 
+        // Note: This same method, but then for TextReader, is in Methods.ReadNumbers.cs; it's called "_DiscardMicrosoftTimeZoneOffset".
         static readonly MethodInfo DiscardMicrosoftTimeZoneOffsetThunkReader = typeof(Methods).GetMethod("_DiscardMicrosoftTimeZoneOffsetThunkReader", BindingFlags.Static | BindingFlags.NonPublic);
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static void _DiscardMicrosoftTimeZoneOffsetThunkReader(ref ThunkReader reader)
         {
-            // this is a special case when reading timezone information for NewtsonsoftStyle DateTimes
+            // this is a special case when reading timezone information for MicrosoftStyle DateTimes
             //   so far as I can tell this is pointless data, the millisecond offset is still UTC relative
             //   so just use that... should validate that this correct though
             // max +9999

--- a/JilTests/DeserializeTests.cs
+++ b/JilTests/DeserializeTests.cs
@@ -4584,7 +4584,7 @@ namespace JilTests
                 Assert.AreEqual(dto, res);
             }
 
-            // Newtsonsoft
+            // Newtonsoft
             {
                 var newtonsoft = 
                     Newtonsoft.Json.JsonSerializer.Create(


### PR DESCRIPTION
Also added a descriptive comment to indicate the same logic is
implemented twice (One for TextReader and one for ThunkReader).