### PR TITLE
Issue 143

### DIFF
--- a/Jil/Common/Utils.cs
+++ b/Jil/Common/Utils.cs
@@ -1278,7 +1278,8 @@ namespace Jil.Common
             return false;
         }
 
-        private static long[] PowersOf10 = new[] {
+        private static long[] PowersOf10 = new[] 
+        {
             1L,
             10L, 
             100L, 
@@ -1291,7 +1292,8 @@ namespace Jil.Common
         };
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static long Pow10(int power) {
+        public static long Pow10(int power) 
+        {
             if (power < PowersOf10.Length)
                 return PowersOf10[power];
             return (long)Math.Pow(10, power);

--- a/Jil/Common/Utils.cs
+++ b/Jil/Common/Utils.cs
@@ -9,6 +9,7 @@ using System.Reflection.Emit;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
 
 namespace Jil.Common
 {
@@ -1275,6 +1276,25 @@ namespace Jil.Common
             }
 
             return false;
+        }
+
+        private static long[] PowersOf10 = new[] {
+            1L,
+            10L, 
+            100L, 
+            1000L, 
+            10000L, 
+            100000L,
+            1000000L,
+            10000000L,
+            100000000L
+        };
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static long Pow10(int power) {
+            if (power < PowersOf10.Length)
+                return PowersOf10[power];
+            return (long)Math.Pow(10, power);
         }
     }
 }

--- a/Jil/Deserialize/Methods.ISO8601DateTime.cs
+++ b/Jil/Deserialize/Methods.ISO8601DateTime.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
+using Jil.Common;
 
 namespace Jil.Deserialize
 {
@@ -679,7 +680,7 @@ namespace Jil.Deserialize
                 if (fracLength == 0) throw new DeserializationException("Expected fractional part of ISO8601 time", reader, false);
 
                 long hoursAsTicks = hour * HoursToTicks;
-                hoursAsTicks += frac * 36 * (long)Math.Pow(10, 9 - fracLength);
+                hoursAsTicks += frac * 36 * Utils.Pow10(9 - fracLength);
 
                 return TimeSpan.FromTicks(hoursAsTicks);
             }
@@ -755,7 +756,7 @@ namespace Jil.Deserialize
 
                     long hoursAsTicks = hour * HoursToTicks;
                     long minsAsTicks = min * MinutesToTicks;
-                    minsAsTicks += frac * 6 * (long)Math.Pow(10, 8 - fracLength);
+                    minsAsTicks += frac * 6 * Utils.Pow10(8 - fracLength);
 
                     return TimeSpan.FromTicks(hoursAsTicks + minsAsTicks);
                 }
@@ -805,7 +806,7 @@ namespace Jil.Deserialize
                     long hoursAsTicks = hour * HoursToTicks;
                     long minsAsTicks = min * MinutesToTicks;
                     long secsAsTicks = secs * SecondsToTicks;
-                    secsAsTicks += frac * (long)Math.Pow(10, 7 - fracLength);
+                    secsAsTicks += frac * Utils.Pow10(7 - fracLength);
 
                     return TimeSpan.FromTicks(hoursAsTicks + minsAsTicks + secsAsTicks);
                 }
@@ -869,7 +870,7 @@ namespace Jil.Deserialize
 
                     long hoursAsTicks = hour * HoursToTicks;
                     long minsAsTicks = min * MinutesToTicks;
-                    minsAsTicks += frac * 6 * (long)Math.Pow(10, 8 - fracLength);
+                    minsAsTicks += frac * 6 * Utils.Pow10(8 - fracLength);
 
                     return TimeSpan.FromTicks(hoursAsTicks + minsAsTicks);
                 }
@@ -918,7 +919,7 @@ namespace Jil.Deserialize
                     long hoursAsTicks = hour * HoursToTicks;
                     long minsAsTicks = min * MinutesToTicks;
                     long secsAsTicks = secs * SecondsToTicks;
-                    secsAsTicks += frac * (long)Math.Pow(10, 7 - fracLength);
+                    secsAsTicks += frac * Utils.Pow10(7 - fracLength);
 
                     return TimeSpan.FromTicks(hoursAsTicks + minsAsTicks + secsAsTicks);
                 }

--- a/Jil/Deserialize/Methods.ISO8601DateTime.cs
+++ b/Jil/Deserialize/Methods.ISO8601DateTime.cs
@@ -666,17 +666,20 @@ namespace Jil.Deserialize
                 {
                     c = buffer[start];
                     if (c < '0' || c > '9') throw new DeserializationException("Expected digit", reader, false);
-                    frac *= 10;
-                    frac += (c - '0');
 
-                    fracLength++;
+                    if (fracLength < 9) {
+                        frac *= 10;
+                        frac += (c - '0');
+                        fracLength++;
+                    }
+
                     start++;
                 }
 
                 if (fracLength == 0) throw new DeserializationException("Expected fractional part of ISO8601 time", reader, false);
 
                 long hoursAsTicks = hour * HoursToTicks;
-                hoursAsTicks += (long)(((double)frac) / Math.Pow(10, fracLength) * HoursToTicks);
+                hoursAsTicks += frac * 36 * (long)Math.Pow(10, 9 - fracLength);
 
                 return TimeSpan.FromTicks(hoursAsTicks);
             }
@@ -737,10 +740,14 @@ namespace Jil.Deserialize
                     {
                         c = buffer[start];
                         if (c < '0' || c > '9') throw new DeserializationException("Expected digit", reader, false);
-                        frac *= 10;
-                        frac += (c - '0');
 
-                        fracLength++;
+                        // Max precision of TimeSpan.FromTicks
+                        if (fracLength < 8) {
+                            frac *= 10;
+                            frac += (c - '0');
+                            fracLength++;
+                        }
+
                         start++;
                     }
 
@@ -748,7 +755,7 @@ namespace Jil.Deserialize
 
                     long hoursAsTicks = hour * HoursToTicks;
                     long minsAsTicks = min * MinutesToTicks;
-                    minsAsTicks += (long)(((double)frac) / Math.Pow(10, fracLength) * MinutesToTicks);
+                    minsAsTicks += frac * 6 * (long)Math.Pow(10, 8 - fracLength);
 
                     return TimeSpan.FromTicks(hoursAsTicks + minsAsTicks);
                 }
@@ -783,10 +790,13 @@ namespace Jil.Deserialize
                     {
                         c = buffer[start];
                         if (c < '0' || c > '9') throw new DeserializationException("Expected digit", reader, false);
-                        frac *= 10;
-                        frac += (c - '0');
 
-                        fracLength++;
+                        if (fracLength < 7) {
+                            frac *= 10;
+                            frac += (c - '0');
+                            fracLength++;
+                        }
+
                         start++;
                     }
 
@@ -795,7 +805,7 @@ namespace Jil.Deserialize
                     long hoursAsTicks = hour * HoursToTicks;
                     long minsAsTicks = min * MinutesToTicks;
                     long secsAsTicks = secs * SecondsToTicks;
-                    secsAsTicks += (long)(((double)frac) / Math.Pow(10, fracLength) * SecondsToTicks);
+                    secsAsTicks += frac * (long)Math.Pow(10, 7 - fracLength);
 
                     return TimeSpan.FromTicks(hoursAsTicks + minsAsTicks + secsAsTicks);
                 }
@@ -844,10 +854,14 @@ namespace Jil.Deserialize
                     {
                         c = buffer[start];
                         if (c < '0' || c > '9') throw new DeserializationException("Expected digit", reader, false);
-                        frac *= 10;
-                        frac += (c - '0');
 
-                        fracLength++;
+                        // Max precision of TimeSpan.FromTicks
+                        if (fracLength < 8) {
+                            frac *= 10;
+                            frac += (c - '0');
+                            fracLength++;
+                        }
+
                         start++;
                     }
 
@@ -855,7 +869,7 @@ namespace Jil.Deserialize
 
                     long hoursAsTicks = hour * HoursToTicks;
                     long minsAsTicks = min * MinutesToTicks;
-                    minsAsTicks += (long)(((double)frac) / Math.Pow(10, fracLength) * MinutesToTicks);
+                    minsAsTicks += frac * 6 * (long)Math.Pow(10, 8 - fracLength);
 
                     return TimeSpan.FromTicks(hoursAsTicks + minsAsTicks);
                 }
@@ -889,10 +903,13 @@ namespace Jil.Deserialize
                     {
                         c = buffer[start];
                         if (c < '0' || c > '9') throw new DeserializationException("Expected digit", reader, false);
-                        frac *= 10;
-                        frac += (c - '0');
 
-                        fracLength++;
+                        if (fracLength < 7) {
+                            frac *= 10;
+                            frac += (c - '0');
+                            fracLength++;
+                        }
+
                         start++;
                     }
 
@@ -901,7 +918,7 @@ namespace Jil.Deserialize
                     long hoursAsTicks = hour * HoursToTicks;
                     long minsAsTicks = min * MinutesToTicks;
                     long secsAsTicks = secs * SecondsToTicks;
-                    secsAsTicks += (long)(((double)frac) / Math.Pow(10, fracLength) * SecondsToTicks);
+                    secsAsTicks += frac * (long)Math.Pow(10, 7 - fracLength);
 
                     return TimeSpan.FromTicks(hoursAsTicks + minsAsTicks + secsAsTicks);
                 }

--- a/Jil/Deserialize/Methods.ISO8601DateTime.cs
+++ b/Jil/Deserialize/Methods.ISO8601DateTime.cs
@@ -668,7 +668,9 @@ namespace Jil.Deserialize
                     c = buffer[start];
                     if (c < '0' || c > '9') throw new DeserializationException("Expected digit", reader, false);
 
-                    if (fracLength < 9) {
+                    // Max precision of TimeSpan.FromTicks
+                    if (fracLength < 9) 
+                    {
                         frac *= 10;
                         frac += (c - '0');
                         fracLength++;
@@ -743,7 +745,8 @@ namespace Jil.Deserialize
                         if (c < '0' || c > '9') throw new DeserializationException("Expected digit", reader, false);
 
                         // Max precision of TimeSpan.FromTicks
-                        if (fracLength < 8) {
+                        if (fracLength < 8) 
+                        {
                             frac *= 10;
                             frac += (c - '0');
                             fracLength++;
@@ -792,7 +795,9 @@ namespace Jil.Deserialize
                         c = buffer[start];
                         if (c < '0' || c > '9') throw new DeserializationException("Expected digit", reader, false);
 
-                        if (fracLength < 7) {
+                        // Max precision of TimeSpan.FromTicks
+                        if (fracLength < 7) 
+                        {
                             frac *= 10;
                             frac += (c - '0');
                             fracLength++;
@@ -857,7 +862,8 @@ namespace Jil.Deserialize
                         if (c < '0' || c > '9') throw new DeserializationException("Expected digit", reader, false);
 
                         // Max precision of TimeSpan.FromTicks
-                        if (fracLength < 8) {
+                        if (fracLength < 8) 
+                        {
                             frac *= 10;
                             frac += (c - '0');
                             fracLength++;
@@ -905,7 +911,9 @@ namespace Jil.Deserialize
                         c = buffer[start];
                         if (c < '0' || c > '9') throw new DeserializationException("Expected digit", reader, false);
 
-                        if (fracLength < 7) {
+                        // Max precision of TimeSpan.FromTicks
+                        if (fracLength < 7) 
+                        {
                             frac *= 10;
                             frac += (c - '0');
                             fracLength++;

--- a/Jil/Deserialize/Methods.ThunkReader.cs
+++ b/Jil/Deserialize/Methods.ThunkReader.cs
@@ -3684,6 +3684,7 @@ namespace Jil.Deserialize
                     c = buffer[start];
                     if (c < '0' || c > '9') throw new DeserializationException("Expected digit", ref reader, false);
 
+                    // Max precision of TimeSpan.FromTicks
                     if (fracLength < 9) 
                     {
                         frac *= 10;
@@ -3759,6 +3760,7 @@ namespace Jil.Deserialize
                         c = buffer[start];
                         if (c < '0' || c > '9') throw new DeserializationException("Expected digit", ref reader, false);
 
+                        // Max precision of TimeSpan.FromTicks
                         if (fracLength < 8) 
                         {
                             frac *= 10;
@@ -3809,6 +3811,7 @@ namespace Jil.Deserialize
                         c = buffer[start];
                         if (c < '0' || c > '9') throw new DeserializationException("Expected digit", ref reader, false);
 
+                        // Max precision of TimeSpan.FromTicks
                         if (fracLength < 7) 
                         {
                             frac *= 10;
@@ -3874,6 +3877,7 @@ namespace Jil.Deserialize
                         c = buffer[start];
                         if (c < '0' || c > '9') throw new DeserializationException("Expected digit", ref reader, false);
 
+                        // Max precision of TimeSpan.FromTicks
                         if (fracLength < 8) 
                         {
                             frac *= 10;
@@ -3923,6 +3927,7 @@ namespace Jil.Deserialize
                         c = buffer[start];
                         if (c < '0' || c > '9') throw new DeserializationException("Expected digit", ref reader, false);
 
+                        // Max precision of TimeSpan.FromTicks
                         if (fracLength < 7) 
                         {
                             frac *= 10;

--- a/Jil/DeserializeDynamic/Methods.ISO8601DateTime.cs
+++ b/Jil/DeserializeDynamic/Methods.ISO8601DateTime.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Jil.Common;
 
 namespace Jil.DeserializeDynamic
 {
@@ -833,7 +834,7 @@ namespace Jil.DeserializeDynamic
                 if (fracLength == 0) return false;
 
                 long hoursAsTicks = hour * HoursToTicks;
-                hoursAsTicks += frac * 36 * (long)Math.Pow(10, 9 - fracLength);
+                hoursAsTicks += frac * 36 * Utils.Pow10(9 - fracLength);
 
                 ts = TimeSpan.FromTicks(hoursAsTicks);
                 return true;
@@ -910,7 +911,7 @@ namespace Jil.DeserializeDynamic
 
                     long hoursAsMilliseconds = hour * HoursToTicks;
                     long minsAsMilliseconds = min * MinutesToTicks;
-                    minsAsMilliseconds += frac * 6 * (long)Math.Pow(10, 8 - fracLength);
+                    minsAsMilliseconds += frac * 6 * Utils.Pow10(8 - fracLength);
 
                     ts = TimeSpan.FromTicks(hoursAsMilliseconds + minsAsMilliseconds);
                     return true;
@@ -962,7 +963,7 @@ namespace Jil.DeserializeDynamic
                     long hoursAsMilliseconds = hour * HoursToTicks;
                     long minsAsMilliseconds = min * MinutesToTicks;
                     long secsAsMilliseconds = secs * SecondsToTicks;
-                    secsAsMilliseconds += frac * (long)Math.Pow(10, 7 - fracLength);
+                    secsAsMilliseconds += frac * Utils.Pow10(7 - fracLength);
 
                     ts = TimeSpan.FromTicks(hoursAsMilliseconds + minsAsMilliseconds + secsAsMilliseconds);
                     return true;
@@ -1027,7 +1028,7 @@ namespace Jil.DeserializeDynamic
 
                     long hoursAsMilliseconds = hour * HoursToTicks;
                     long minsAsMilliseconds = min * MinutesToTicks;
-                    minsAsMilliseconds += frac * 6 * (long)Math.Pow(10, 8 - fracLength);
+                    minsAsMilliseconds += frac * 6 * Utils.Pow10(8 - fracLength);
 
                     ts = TimeSpan.FromTicks(hoursAsMilliseconds + minsAsMilliseconds);
                     return true;
@@ -1078,7 +1079,7 @@ namespace Jil.DeserializeDynamic
                     long hoursAsMilliseconds = hour * HoursToTicks;
                     long minsAsMilliseconds = min * MinutesToTicks;
                     long secsAsMilliseconds = secs * SecondsToTicks;
-                    secsAsMilliseconds += frac * (long)Math.Pow(10, 7 - fracLength);
+                    secsAsMilliseconds += frac * Utils.Pow10(7 - fracLength);
 
                     ts = TimeSpan.FromTicks(hoursAsMilliseconds + minsAsMilliseconds + secsAsMilliseconds);
                     return true;

--- a/Jil/DeserializeDynamic/Methods.ISO8601DateTime.cs
+++ b/Jil/DeserializeDynamic/Methods.ISO8601DateTime.cs
@@ -820,17 +820,20 @@ namespace Jil.DeserializeDynamic
                 {
                     c = str[start];
                     if (c < '0' || c > '9') return false;
-                    frac *= 10;
-                    frac += (c - '0');
 
-                    fracLength++;
+                    if (fracLength < 9) {
+                        frac *= 10;
+                        frac += (c - '0');
+                        fracLength++;
+                    }
+
                     start++;
                 }
 
                 if (fracLength == 0) return false;
 
                 long hoursAsTicks = hour * HoursToTicks;
-                hoursAsTicks += (long)(((double)frac) / Math.Pow(10, fracLength) * HoursToTicks);
+                hoursAsTicks += frac * 36 * (long)Math.Pow(10, 9 - fracLength);
 
                 ts = TimeSpan.FromTicks(hoursAsTicks);
                 return true;
@@ -893,10 +896,13 @@ namespace Jil.DeserializeDynamic
                     {
                         c = str[start];
                         if (c < '0' || c > '9') return false;
-                        frac *= 10;
-                        frac += (c - '0');
 
-                        fracLength++;
+                        if (fracLength < 8) {
+                            frac *= 10;
+                            frac += (c - '0');
+                            fracLength++;
+                        }
+
                         start++;
                     }
 
@@ -904,7 +910,7 @@ namespace Jil.DeserializeDynamic
 
                     long hoursAsMilliseconds = hour * HoursToTicks;
                     long minsAsMilliseconds = min * MinutesToTicks;
-                    minsAsMilliseconds += (long)(((double)frac) / Math.Pow(10, fracLength) * MinutesToTicks);
+                    minsAsMilliseconds += frac * 6 * (long)Math.Pow(10, 8 - fracLength);
 
                     ts = TimeSpan.FromTicks(hoursAsMilliseconds + minsAsMilliseconds);
                     return true;
@@ -941,10 +947,13 @@ namespace Jil.DeserializeDynamic
                     {
                         c = str[start];
                         if (c < '0' || c > '9') return false;
-                        frac *= 10;
-                        frac += (c - '0');
 
-                        fracLength++;
+                        if (fracLength < 7) {
+                            frac *= 10;
+                            frac += (c - '0');
+                            fracLength++;
+                        }
+
                         start++;
                     }
 
@@ -953,7 +962,7 @@ namespace Jil.DeserializeDynamic
                     long hoursAsMilliseconds = hour * HoursToTicks;
                     long minsAsMilliseconds = min * MinutesToTicks;
                     long secsAsMilliseconds = secs * SecondsToTicks;
-                    secsAsMilliseconds += (long)(((double)frac) / Math.Pow(10, fracLength) * SecondsToTicks);
+                    secsAsMilliseconds += frac * (long)Math.Pow(10, 7 - fracLength);
 
                     ts = TimeSpan.FromTicks(hoursAsMilliseconds + minsAsMilliseconds + secsAsMilliseconds);
                     return true;
@@ -1004,10 +1013,13 @@ namespace Jil.DeserializeDynamic
                     {
                         c = str[start];
                         if (c < '0' || c > '9') return false;
-                        frac *= 10;
-                        frac += (c - '0');
 
-                        fracLength++;
+                        if (fracLength < 8) {
+                            frac *= 10;
+                            frac += (c - '0');
+                            fracLength++;                        
+                        }
+
                         start++;
                     }
 
@@ -1015,7 +1027,7 @@ namespace Jil.DeserializeDynamic
 
                     long hoursAsMilliseconds = hour * HoursToTicks;
                     long minsAsMilliseconds = min * MinutesToTicks;
-                    minsAsMilliseconds += (long)(((double)frac) / Math.Pow(10, fracLength) * MinutesToTicks);
+                    minsAsMilliseconds += frac * 6 * (long)Math.Pow(10, 8 - fracLength);
 
                     ts = TimeSpan.FromTicks(hoursAsMilliseconds + minsAsMilliseconds);
                     return true;
@@ -1051,10 +1063,13 @@ namespace Jil.DeserializeDynamic
                     {
                         c = str[start];
                         if (c < '0' || c > '9') return false;
-                        frac *= 10;
-                        frac += (c - '0');
 
-                        fracLength++;
+                        if (fracLength < 7) {
+                            frac *= 10;
+                            frac += (c - '0');
+                            fracLength++;
+                        }
+   
                         start++;
                     }
 
@@ -1063,7 +1078,7 @@ namespace Jil.DeserializeDynamic
                     long hoursAsMilliseconds = hour * HoursToTicks;
                     long minsAsMilliseconds = min * MinutesToTicks;
                     long secsAsMilliseconds = secs * SecondsToTicks;
-                    secsAsMilliseconds += (long)(((double)frac) / Math.Pow(10, fracLength) * SecondsToTicks);
+                    secsAsMilliseconds += frac * (long)Math.Pow(10, 7 - fracLength);
 
                     ts = TimeSpan.FromTicks(hoursAsMilliseconds + minsAsMilliseconds + secsAsMilliseconds);
                     return true;

--- a/Jil/DeserializeDynamic/Methods.ISO8601DateTime.cs
+++ b/Jil/DeserializeDynamic/Methods.ISO8601DateTime.cs
@@ -822,7 +822,9 @@ namespace Jil.DeserializeDynamic
                     c = str[start];
                     if (c < '0' || c > '9') return false;
 
-                    if (fracLength < 9) {
+                    // Max precision of TimeSpan.FromTicks
+                    if (fracLength < 9) 
+                    {
                         frac *= 10;
                         frac += (c - '0');
                         fracLength++;
@@ -898,7 +900,9 @@ namespace Jil.DeserializeDynamic
                         c = str[start];
                         if (c < '0' || c > '9') return false;
 
-                        if (fracLength < 8) {
+                        // Max precision of TimeSpan.FromTicks
+                        if (fracLength < 8) 
+                        {
                             frac *= 10;
                             frac += (c - '0');
                             fracLength++;
@@ -949,7 +953,9 @@ namespace Jil.DeserializeDynamic
                         c = str[start];
                         if (c < '0' || c > '9') return false;
 
-                        if (fracLength < 7) {
+                        // Max precision of TimeSpan.FromTicks
+                        if (fracLength < 7) 
+                        {
                             frac *= 10;
                             frac += (c - '0');
                             fracLength++;
@@ -1015,7 +1021,9 @@ namespace Jil.DeserializeDynamic
                         c = str[start];
                         if (c < '0' || c > '9') return false;
 
-                        if (fracLength < 8) {
+                        // Max precision of TimeSpan.FromTicks
+                        if (fracLength < 8) 
+                        {
                             frac *= 10;
                             frac += (c - '0');
                             fracLength++;                        
@@ -1065,7 +1073,9 @@ namespace Jil.DeserializeDynamic
                         c = str[start];
                         if (c < '0' || c > '9') return false;
 
-                        if (fracLength < 7) {
+                        // Max precision of TimeSpan.FromTicks
+                        if (fracLength < 7) 
+                        {
                             frac *= 10;
                             frac += (c - '0');
                             fracLength++;

--- a/JilTests/DeserializeDynamicTests.cs
+++ b/JilTests/DeserializeDynamicTests.cs
@@ -1282,6 +1282,24 @@ namespace JilTests
         }
 
         [TestMethod]
+        public void Issue143DateTime() 
+        {
+            var date = new DateTime(21, DateTimeKind.Utc);
+            var str = JSON.Serialize(date, Options.ISO8601);
+            var result = (DateTime)JSON.DeserializeDynamic(str, Options.ISO8601);
+            Assert.AreEqual(date.Ticks, result.Ticks);
+        }
+
+        [TestMethod]
+        public void Issue143TimeSpan() 
+        {
+            var span = new TimeSpan(21);
+            var str = JSON.Serialize(span, Options.ISO8601);
+            var result = (TimeSpan)JSON.DeserializeDynamic(str, Options.ISO8601);
+            Assert.AreEqual(span.Ticks, result.Ticks);
+        }
+
+        [TestMethod]
         public void SecondDateTimes()
         {
             var dt = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);

--- a/JilTests/DeserializeDynamicTests.cs
+++ b/JilTests/DeserializeDynamicTests.cs
@@ -1291,12 +1291,49 @@ namespace JilTests
         }
 
         [TestMethod]
+        public void Issue143DateTimeFractionOverflow() 
+        {
+            var date = new DateTime(21, DateTimeKind.Utc);
+            var str = "\"0001-01-01T00:00:00.000002100001Z\"";
+            var result = (DateTime)JSON.DeserializeDynamic(str, Options.ISO8601);
+            Assert.AreEqual(date.Ticks, result.Ticks);
+        }
+
+        [TestMethod]
         public void Issue143TimeSpan() 
         {
             var span = new TimeSpan(21);
             var str = JSON.Serialize(span, Options.ISO8601);
             var result = (TimeSpan)JSON.DeserializeDynamic(str, Options.ISO8601);
             Assert.AreEqual(span.Ticks, result.Ticks);
+        }
+
+        [TestMethod]
+        public void Issue143TimeSpanFractionOverflow() 
+        {
+            var span = new TimeSpan(21);
+            var str = "\"PT0.000002100001S\"";
+            var result = (TimeSpan)JSON.DeserializeDynamic(str, Options.ISO8601);
+            Assert.AreEqual(span.Ticks, result.Ticks);
+        }
+
+        [TestMethod]
+        public void Issue143DateTimeOffset() 
+        {
+            var offset = new DateTimeOffset(new DateTime(21, DateTimeKind.Utc), TimeSpan.Zero);
+            var str = JSON.Serialize(offset, Options.ISO8601);
+            var result = (DateTimeOffset)JSON.DeserializeDynamic(str, Options.ISO8601);
+            Assert.AreEqual(offset.Ticks, result.Ticks);
+        }
+
+
+        [TestMethod]
+        public void Issue143DateTimeOffsetFractionOverflow() 
+        {
+            var offset = new DateTimeOffset(new DateTime(21, DateTimeKind.Utc), TimeSpan.Zero);
+            var str = "\"0001-01-01T00:00:00.000002100001Z\"";
+            var result = (DateTimeOffset)JSON.DeserializeDynamic(str, Options.ISO8601);
+            Assert.AreEqual(offset.Ticks, result.Ticks);
         }
 
         [TestMethod]

--- a/JilTests/DeserializeTests.cs
+++ b/JilTests/DeserializeTests.cs
@@ -1825,7 +1825,8 @@ namespace JilTests
         }
 
         [TestMethod]
-        public void Issue143DateTime() {
+        public void Issue143DateTime() 
+        {
             var date = new DateTime(21, DateTimeKind.Utc);
             var str = JSON.Serialize(date, Options.ISO8601);
             
@@ -1839,7 +1840,23 @@ namespace JilTests
         }
 
         [TestMethod]
-        public void Issue143TimeSpan() {
+        public void Issue143DateTimeFractionOverflow() 
+        {
+            var date = new DateTime(21, DateTimeKind.Utc);
+            var str = "\"0001-01-01T00:00:00.0000021001Z\"";
+
+            // ThunkReader
+            var result = JSON.Deserialize<DateTime>(str, Options.ISO8601);
+            Assert.AreEqual(date.Ticks, result.Ticks);
+
+            // TextReader
+            result = JSON.Deserialize<DateTime>(new StringReader(str), Options.ISO8601);
+            Assert.AreEqual(date.Ticks, result.Ticks);
+        }
+
+        [TestMethod]
+        public void Issue143TimeSpan() 
+        {
             var span = new TimeSpan(21);
             var str = JSON.Serialize(span, Options.ISO8601);
 
@@ -1850,6 +1867,53 @@ namespace JilTests
             // TextReader
             result = JSON.Deserialize<TimeSpan>(new StringReader(str), Options.ISO8601);
             Assert.AreEqual(span.Ticks, result.Ticks);
+        }
+
+
+        [TestMethod]
+        public void Issue143TimeSpanFractionOverflow() 
+        {
+            var date = new TimeSpan(21);
+            var str = "\"PT0.00000210000001S\"";
+
+            // ThunkReader
+            var result = JSON.Deserialize<TimeSpan>(str, Options.ISO8601);
+            Assert.AreEqual(date.Ticks, result.Ticks);
+
+            // TextReader
+            result = JSON.Deserialize<TimeSpan>(new StringReader(str), Options.ISO8601);
+            Assert.AreEqual(date.Ticks, result.Ticks);
+        }
+
+        [TestMethod]
+        public void Issue143DateTimeOffset() 
+        {
+            var offset = new DateTimeOffset(new DateTime(21, DateTimeKind.Utc), TimeSpan.Zero);
+            var str = JSON.Serialize(offset, Options.ISO8601);
+
+            // ThunkReader
+            var result = JSON.Deserialize<DateTimeOffset>(str, Options.ISO8601);
+            Assert.AreEqual(offset.Ticks, result.Ticks);
+
+            // TextReader
+            result = JSON.Deserialize<DateTimeOffset>(new StringReader(str), Options.ISO8601);
+            Assert.AreEqual(offset.Ticks, result.Ticks);
+        }
+
+
+        [TestMethod]
+        public void Issue143DateTimeOffsetFractionOverflow() 
+        {
+            var offset = new DateTimeOffset(new DateTime(21, DateTimeKind.Utc), TimeSpan.Zero);
+            var str = "\"0001-01-01T00:00:00.000002100001Z\"";
+
+            // ThunkReader
+            var result = JSON.Deserialize<DateTimeOffset>(str, Options.ISO8601);
+            Assert.AreEqual(offset.Ticks, result.Ticks);
+
+            // TextReader
+            result = JSON.Deserialize<DateTimeOffset>(new StringReader(str), Options.ISO8601);
+            Assert.AreEqual(offset.Ticks, result.Ticks);
         }
 
         [TestMethod]

--- a/JilTests/DeserializeTests.cs
+++ b/JilTests/DeserializeTests.cs
@@ -1828,8 +1828,13 @@ namespace JilTests
         public void Issue143DateTime() {
             var date = new DateTime(21, DateTimeKind.Utc);
             var str = JSON.Serialize(date, Options.ISO8601);
+            
+            // ThunkReader
             var result = JSON.Deserialize<DateTime>(str, Options.ISO8601);
+            Assert.AreEqual(date.Ticks, result.Ticks);
 
+            // TextReader
+            result = JSON.Deserialize<DateTime>(new StringReader(str), Options.ISO8601);
             Assert.AreEqual(date.Ticks, result.Ticks);
         }
 
@@ -1837,8 +1842,13 @@ namespace JilTests
         public void Issue143TimeSpan() {
             var span = new TimeSpan(21);
             var str = JSON.Serialize(span, Options.ISO8601);
-            var result = JSON.Deserialize<DateTime>(str, Options.ISO8601);
 
+            // ThunkReader
+            var result = JSON.Deserialize<TimeSpan>(str, Options.ISO8601);
+            Assert.AreEqual(span.Ticks, result.Ticks);
+
+            // TextReader
+            result = JSON.Deserialize<TimeSpan>(new StringReader(str), Options.ISO8601);
             Assert.AreEqual(span.Ticks, result.Ticks);
         }
 

--- a/JilTests/DeserializeTests.cs
+++ b/JilTests/DeserializeTests.cs
@@ -1825,6 +1825,24 @@ namespace JilTests
         }
 
         [TestMethod]
+        public void Issue143DateTime() {
+            var date = new DateTime(21, DateTimeKind.Utc);
+            var str = JSON.Serialize(date, Options.ISO8601);
+            var result = JSON.Deserialize<DateTime>(str, Options.ISO8601);
+
+            Assert.AreEqual(date.Ticks, result.Ticks);
+        }
+
+        [TestMethod]
+        public void Issue143TimeSpan() {
+            var span = new TimeSpan(21);
+            var str = JSON.Serialize(span, Options.ISO8601);
+            var result = JSON.Deserialize<DateTime>(str, Options.ISO8601);
+
+            Assert.AreEqual(span.Ticks, result.Ticks);
+        }
+
+        [TestMethod]
         public void SecondDateTimes()
         {
             var dt = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);


### PR DESCRIPTION
This pull-request fixes #143 by replacing the floating point calculation with direct to-ticks calculations. Tests have been added that hit all of the different ISO8601 parsing methods (TimeSpan/DateTime, TextReader/ThunkReader, Not dynamic/Dynamic).