### PR TITLE
Fixed the Jil.StrongName project still referencing an old Sigil version

### DIFF
--- a/Jil.StrongName/Jil.StrongName.csproj
+++ b/Jil.StrongName/Jil.StrongName.csproj
@@ -42,7 +42,7 @@
   <ItemGroup>
     <Reference Include="Sigil, Version=4.4.0.0, Culture=neutral, PublicKeyToken=2d06c3494341c8ab, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Sigil.4.4.0\lib\net45\Sigil.dll</HintPath>
+      <HintPath>..\packages\Sigil.4.5.0\lib\net45\Sigil.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
The Jil.StrongName project was still referencing Sigil 4.4.0, instead of the latest 4.5.0.
The 4.4.0 version no longer exists in the repository and causes building of this project to fail.