### PR TITLE
Issue 150 151

### DIFF
--- a/Jil/Deserialize/InlineDeserializer.cs
+++ b/Jil/Deserialize/InlineDeserializer.cs
@@ -1027,7 +1027,7 @@ namespace Jil.Deserialize
             throw new ConstructionException("Unexpected type: " + type);
         }
 
-        void ReadNullable(Type nullableType)
+        void ReadNullable(MemberInfo nullableMember, Type nullableType)
         {
             var underlying = Nullable.GetUnderlyingType(nullableType);
 
@@ -1042,7 +1042,7 @@ namespace Jil.Deserialize
                 Emit.LoadConstant('n');             // int n
                 Emit.BranchIfEqual(maybeNull);      // --empty--
 
-                Build(underlying);                  // underlying
+                Build(nullableMember, underlying);                  // underlying
                 Emit.NewObject(nullableConst);      // nullableType
                 Emit.Branch(done);                  // nullableType
 
@@ -1060,7 +1060,7 @@ namespace Jil.Deserialize
             }
         }
 
-        void ReadList(Type listType)
+        void ReadList(MemberInfo listMember, Type listType)
         {
             var elementType = listType.GetListInterface().GetGenericArguments()[0];
 
@@ -1141,7 +1141,7 @@ namespace Jil.Deserialize
                 RawPeekChar();                                  // listType int 
                 Emit.LoadConstant(']');                         // listType int ']'
                 Emit.BranchIfEqual(done);                       // listType(*?)
-                Build(elementType);                             // listType(*?) elementType
+                Build(listMember, elementType);                             // listType(*?) elementType
                 Emit.CallVirtual(addMtd);                       // --empty--
 
                 var startLoop = Emit.DefineLabel();
@@ -1164,7 +1164,7 @@ namespace Jil.Deserialize
                 Emit.MarkLabel(nextItem);           // listType(*?) int
                 Emit.Pop();                         // listType(*?)
                 ConsumeWhiteSpace();                // listType(*?)
-                Build(elementType);                 // listType(*?) elementType
+                Build(listMember, elementType);                 // listType(*?) elementType
                 Emit.CallVirtual(addMtd);           // --empty--
                 Emit.Branch(startLoop);             // --empty--
 
@@ -1184,7 +1184,7 @@ namespace Jil.Deserialize
             }
         }
 
-        void ReadDictionary(Type dictType)
+        void ReadDictionary(MemberInfo dictionaryMember, Type dictType)
         {
             var keyType = dictType.GetDictionaryInterface().GetGenericArguments()[0];
 
@@ -1252,25 +1252,25 @@ namespace Jil.Deserialize
                 Emit.BranchIfEqual(done);   // dictType(*?)
                 if (keyType == typeof(string))
                 {
-                    Build(typeof(string));  // dictType(*?) string
+                    Build(dictionaryMember, typeof(string));  // dictType(*?) string
                 }
                 else
                 {
-                    if (keyIsInteger)
+                    if (keyIsInteger || (keyIsEnum && dictionaryMember != null && dictionaryMember.ShouldConvertEnum(keyType)))
                     {
                         ExpectQuote();          // dictType(*?)
-                        Build(keyType);         // dictType(*?) integer
+                        Build(dictionaryMember, keyType);         // dictType(*?) integer
                         ExpectQuote();          // dictType(*?) integer
                     }
                     else
                     {
-                        Build(keyType);         // dictType(*?) enum
+                        Build(dictionaryMember, keyType);         // dictType(*?) enum
                     }
                 }
                 ReadSkipWhitespace();        // dictType(*?) (integer|string|enum)
                 CheckChar(':');              // dictType(*?) (integer|string|enum)
                 ConsumeWhiteSpace();         // dictType(*?) (integer|string|enum)
-                Build(valType);              // dictType(*?) (integer|string|enum) valType
+                Build(dictionaryMember, valType);              // dictType(*?) (integer|string|enum) valType
                 Emit.CallVirtual(addMtd);    // --empty--
 
                 var nextItem = Emit.DefineLabel();
@@ -1294,25 +1294,25 @@ namespace Jil.Deserialize
                 ConsumeWhiteSpace();                // dictType(*?)
                 if (keyType == typeof(string))
                 {
-                    Build(typeof(string));  // dictType(*?) string
+                    Build(dictionaryMember, typeof(string));  // dictType(*?) string
                 }
                 else
                 {
-                    if (keyIsInteger)
+                    if (keyIsInteger || (keyIsEnum && dictionaryMember != null && dictionaryMember.ShouldConvertEnum(keyType)))
                     {
                         ExpectQuote();          // dictType(*?)
-                        Build(keyType);         // dictType(*?) integer
+                        Build(dictionaryMember, keyType);         // dictType(*?) integer
                         ExpectQuote();          // dictType(*?) integer
                     }
                     else
                     {
-                        Build(keyType);         // dictType(*?) enum
+                        Build(dictionaryMember, keyType);         // dictType(*?) enum
                     }
                 }
                 ReadSkipWhitespace();               // dictType(*?) (integer|string|enum)
                 CheckChar(':');                     // dictType(*?) (integer|string|enum)
                 ConsumeWhiteSpace();                // dictType(*?) (integer|string|enum)
-                Build(valType);                     // dictType(*?) (integer|string|enum) valType
+                Build(dictionaryMember, valType);                     // dictType(*?) (integer|string|enum) valType
                 Emit.CallVirtual(addMtd);           // --empty--
                 Emit.Branch(loopStart);             // --empty--
             }
@@ -1550,17 +1550,17 @@ namespace Jil.Deserialize
 
                     Emit.MarkLabel(label);      // objType(*?)
 
-                    var memberAttr = member.GetCustomAttribute<JilDirectiveAttribute>();
-                    if (memberType.IsEnum && memberAttr != null && memberAttr.TreatEnumerationAs != null)
+                    Type convertEnumTo;
+                    if (memberType.IsEnum && member != null && member.ShouldConvertEnum(memberType, out convertEnumTo))
                     {
                         var underlyingEnumType = Enum.GetUnderlyingType(memberType);
 
-                        Build(memberAttr.TreatEnumerationAs);   // objType(*?) SerializeEnumerationAsType
+                        Build(member, convertEnumTo);   // objType(*?) SerializeEnumerationAsType
                         Emit.Convert(underlyingEnumType);       // objType(*?) memberType
                     }
                     else
                     {
-                        Build(memberType);          // objType(*?) memberType
+                        Build(member, memberType);          // objType(*?) memberType
                     }
 
                     if (member is FieldInfo)
@@ -1694,7 +1694,7 @@ namespace Jil.Deserialize
                 Emit.LoadConstant('}');     // objType(*?) int '}'
                 Emit.BranchIfEqual(done);   // objType(*?)
                 Emit.LoadField(order);      // objType(*?) Dictionary<string, int> string
-                Build(typeof(string));      // obType(*?) Dictionary<string, int> string
+                Build(null, typeof(string));      // obType(*?) Dictionary<string, int> string
                 ReadSkipWhitespace();       // objType(*?) Dictionary<string, int> string
                 CheckChar(':');             // objType(*?) Dictionary<string, int> string
                 ConsumeWhiteSpace();        // objType(*?) Dictionary<string, int> string
@@ -1730,17 +1730,17 @@ namespace Jil.Deserialize
 
                     Emit.MarkLabel(label);      // objType(*?)
 
-                    var memberAttr = member.GetCustomAttribute<JilDirectiveAttribute>();
-                    if (memberType.IsEnum && memberAttr != null && memberAttr.TreatEnumerationAs != null)
+                    Type convertEnumTo;
+                    if (memberType.IsEnum && member != null && member.ShouldConvertEnum(memberType, out convertEnumTo))
                     {
                         var underlyingEnumType = Enum.GetUnderlyingType(memberType);
 
-                        Build(memberAttr.TreatEnumerationAs);   // objType(*?) SerializeEnumerationAsType
+                        Build(member, convertEnumTo);   // objType(*?) SerializeEnumerationAsType
                         Emit.Convert(underlyingEnumType);       // objType(*?) memberType
                     }
                     else
                     {
-                        Build(memberType);          // objType(*?) memberType
+                        Build(member, memberType);          // objType(*?) memberType
                     }
 
                     if (member is FieldInfo)
@@ -1775,7 +1775,7 @@ namespace Jil.Deserialize
                 Emit.Pop();                         // objType(*?)
                 ConsumeWhiteSpace();
                 Emit.LoadField(order);              // objType(*?) Dictionary<string, int> string
-                Build(typeof(string));              // objType(*?) Dictionary<string, int> string
+                Build(null, typeof(string));              // objType(*?) Dictionary<string, int> string
                 ReadSkipWhitespace();               // objType(*?) Dictionary<string, int> string
                 CheckChar(':');                     // objType(*?) Dictionary<string, int> string
                 ConsumeWhiteSpace();                // objType(*?) Dictionary<string, int> string
@@ -1853,7 +1853,7 @@ namespace Jil.Deserialize
             Emit.LoadConstant('}');             // int '}'
             Emit.BranchIfEqual(doneNotNull);    // --empty--
             Emit.LoadField(order);              // Dictionary<string, int> string
-            Build(typeof(string));              // Dictionary<string, int> string
+            Build(null, typeof(string));              // Dictionary<string, int> string
             ReadSkipWhitespace();               // Dictionary<string, int> string
             CheckChar(':');                     // Dictionary<string, int> string
             ConsumeWhiteSpace();                // Dictionary<string, int> string
@@ -1886,7 +1886,7 @@ namespace Jil.Deserialize
                 var local = localMap[kv.Key];
 
                 Emit.MarkLabel(label);  // --empty--
-                Build(local.LocalType); // localType
+                Build(null, local.LocalType); // localType
 
                 Emit.StoreLocal(local); // --empty--
 
@@ -1915,7 +1915,7 @@ namespace Jil.Deserialize
             Emit.Pop();                         // --empty--
             ConsumeWhiteSpace();                // --empty--
             Emit.LoadField(order);              // Dictionary<string, int> string
-            Build(typeof(string));              // Dictionary<string, int> string
+            Build(null, typeof(string));              // Dictionary<string, int> string
             ReadSkipWhitespace();               // Dictionary<string, int> string
             CheckChar(':');                     // Dictionary<string, int> string
             ConsumeWhiteSpace();                // Dictionary<string, int> string
@@ -2043,7 +2043,7 @@ namespace Jil.Deserialize
                 var local = localMap[kv.Key];
 
                 Emit.MarkLabel(label);  // --empty--
-                Build(local.LocalType); // localType
+                Build(null, local.LocalType); // localType
 
                 Emit.StoreLocal(local); // --empty--
 
@@ -2135,7 +2135,7 @@ namespace Jil.Deserialize
             }
         }
 
-        void Build(Type forType, bool allowRecursion = true)
+        void Build(MemberInfo forMember, Type forType, bool allowRecursion = true)
         {
             // EXACT MATCH, this is the best way to detect `dynamic`
             if (forType == typeof(object))
@@ -2146,7 +2146,7 @@ namespace Jil.Deserialize
 
             if (forType.IsNullableType())
             {
-                ReadNullable(forType);
+                ReadNullable(forMember, forType);
                 return;
             }
 
@@ -2158,7 +2158,7 @@ namespace Jil.Deserialize
 
             if (forType.IsDictionaryType())
             {
-                ReadDictionary(forType);
+                ReadDictionary(forMember, forType);
                 return;
             }
 
@@ -2167,13 +2167,13 @@ namespace Jil.Deserialize
                 var keyType = forType.GetGenericArguments()[0];
                 var valueType = forType.GetGenericArguments()[1];
                 var fakeDictionary = typeof(Dictionary<,>).MakeGenericType(keyType, valueType);
-                ReadDictionary(fakeDictionary);
+                ReadDictionary(forMember, fakeDictionary);
                 return;
             }
 
             if (forType.IsListType())
             {
-                ReadList(forType);
+                ReadList(forMember, forType);
                 return;
             }
 
@@ -2183,12 +2183,22 @@ namespace Jil.Deserialize
             {
                 var elementType = forType.GetGenericArguments()[0];
                 var fakeList = typeof(List<>).MakeGenericType(elementType);
-                ReadList(fakeList);
+                ReadList(forMember, fakeList);
                 return;
             }
 
             if (forType.IsEnum)
             {
+                Type convertEnumTo;
+                if (forMember != null && forMember.ShouldConvertEnum(forType, out convertEnumTo))
+                {
+                    var underlyingEnumType = Enum.GetUnderlyingType(forType);
+
+                    Build(forMember, convertEnumTo);
+                    Emit.Convert(underlyingEnumType);
+                    return;
+                }
+
                 ReadEnum(forType);
                 return;
             }
@@ -2255,7 +2265,7 @@ namespace Jil.Deserialize
 
             ConsumeWhiteSpace();
 
-            Build(forType, allowRecursion: false);
+            Build(null, forType, allowRecursion: false);
 
             // we have to consume this, otherwise we might succeed with invalid JSON
             ConsumeWhiteSpace();

--- a/Jil/SerializeDynamic/DynamicSerializer.cs
+++ b/Jil/SerializeDynamic/DynamicSerializer.cs
@@ -157,7 +157,17 @@ namespace Jil.SerializeDynamic
         {
             var type = typeof(ForType);
 
-            var key = Tuple.Create(typeof(ForType), opts);
+            Type treatEnumerationAs = null;
+            if (dynamicMember != null)
+            {
+                var attr = dynamicMember.GetCustomAttribute<JilDirectiveAttribute>();
+                if (attr != null && attr.TreatEnumerationAs != null)
+                {
+                    treatEnumerationAs = attr.TreatEnumerationAs;
+                }
+            }
+
+            var key = Tuple.Create(treatEnumerationAs, typeof(ForType), opts);
 
             var ret = (Action<TextWriter, ForType, int>)GetSemiStaticInlineSerializerForCache[key];
             if (ret != null) return ret;

--- a/Jil/SerializeDynamic/DynamicSerializer.cs
+++ b/Jil/SerializeDynamic/DynamicSerializer.cs
@@ -153,7 +153,7 @@ namespace Jil.SerializeDynamic
 
         static readonly Hashtable GetSemiStaticInlineSerializerForCache = new Hashtable();
         static readonly MethodInfo GetSemiStaticInlineSerializerFor = typeof(DynamicSerializer).GetMethod("_GetSemiStaticInlineSerializerFor", BindingFlags.NonPublic | BindingFlags.Static);
-        static Action<TextWriter, ForType, int> _GetSemiStaticInlineSerializerFor<ForType>(Options opts)
+        static Action<TextWriter, ForType, int> _GetSemiStaticInlineSerializerFor<ForType>(MemberInfo dynamicMember, Options opts)
         {
             var type = typeof(ForType);
 
@@ -169,29 +169,31 @@ namespace Jil.SerializeDynamic
             {
                 ret = (Action<TextWriter, ForType, int>)GetSemiStaticInlineSerializerForCache[key];
                 if (ret != null) return ret;
-                GetSemiStaticInlineSerializerForCache[key] = ret = (Action<TextWriter, ForType, int>)builder.Invoke(null, new object[] { cacheType, opts.ShouldPrettyPrint, opts.ShouldExcludeNulls, opts.IsJSONP, opts.UseDateTimeFormat, opts.ShouldIncludeInherited, opts.UseUnspecifiedDateTimeKindBehavior });
+                GetSemiStaticInlineSerializerForCache[key] = ret = (Action<TextWriter, ForType, int>)builder.Invoke(null, new object[] { dynamicMember, cacheType, opts.ShouldPrettyPrint, opts.ShouldExcludeNulls, opts.IsJSONP, opts.UseDateTimeFormat, opts.ShouldIncludeInherited, opts.UseUnspecifiedDateTimeKindBehavior });
             }
 
             return ret;
         }
 
         static Hashtable GetSemiStaticSerializerForCache = new Hashtable();
-        static Action<TextWriter, object, int> GetSemiStaticSerializerFor(Type type, Options opts)
+        static Action<MemberInfo, TextWriter, object, int> GetSemiStaticSerializerFor(Type type, Options opts)
         {
             var key = Tuple.Create(type, opts);
-            var ret = (Action<TextWriter, object, int>)GetSemiStaticSerializerForCache[key];
+            var ret = (Action<MemberInfo, TextWriter, object, int>)GetSemiStaticSerializerForCache[key];
             if (ret != null) return ret;
 
             var getSemiStaticSerializer = GetSemiStaticInlineSerializerFor.MakeGenericMethod(type);
             var invoke = typeof(Action<,,>).MakeGenericType(typeof(TextWriter), type, typeof(int)).GetMethod("Invoke");
 
-            var emit = Emit.NewDynamicMethod(typeof(void), new[] { typeof(TextWriter), typeof(object), typeof(int) }, doVerify: Utils.DoVerify);
+            var emit = Emit.NewDynamicMethod(typeof(void), new[] { typeof(MemberInfo), typeof(TextWriter), typeof(object), typeof(int) }, doVerify: Utils.DoVerify);
 
             var optsFiled = OptionsLookup.GetOptionsFieldFor(opts);
-            emit.LoadField(optsFiled);                              // Options
+
+            emit.LoadArgument(0);                                   // MemberInfo
+            emit.LoadField(optsFiled);                              // MemberInfo Options
             emit.Call(getSemiStaticSerializer);                     // Action<TextWriter, Type, int>
-            emit.LoadArgument(0);                                   // Action<TextWriter, Type, int> TextWriter
-            emit.LoadArgument(1);                                   // Action<TextWriter, Type, int> TextWriter object
+            emit.LoadArgument(1);                                   // Action<TextWriter, Type, int> TextWriter
+            emit.LoadArgument(2);                                   // Action<TextWriter, Type, int> TextWriter object
 
             if (type.IsValueType)
             {
@@ -202,26 +204,26 @@ namespace Jil.SerializeDynamic
                 emit.CastClass(type);                               // Action<TextWriter, Type, int> TextWriter type
             }
 
-            emit.LoadArgument(2);                                   // Action<TextWriter, Type, int> TextWriter type int
+            emit.LoadArgument(3);                                   // Action<TextWriter, Type, int> TextWriter type int
             emit.Call(invoke);                                      // --empty--
             emit.Return();                                          // --empty--
 
             lock (GetSemiStaticSerializerForCache)
             {
-                ret = (Action<TextWriter, object, int>)GetSemiStaticSerializerForCache[key];
+                ret = (Action<MemberInfo, TextWriter, object, int>)GetSemiStaticSerializerForCache[key];
                 if (ret != null) return ret;
 
-                GetSemiStaticSerializerForCache[key] = ret = emit.CreateDelegate<Action<TextWriter, object, int>>(optimizationOptions: Utils.DelegateOptimizationOptions);
+                GetSemiStaticSerializerForCache[key] = ret = emit.CreateDelegate<Action<MemberInfo, TextWriter, object, int>>(optimizationOptions: Utils.DelegateOptimizationOptions);
             }
 
             return ret;
         }
 
-        static void SerializeSemiStatically(TextWriter stream, object val, Options opts, int depth)
+        static void SerializeSemiStatically(MemberInfo dynamicMember, TextWriter stream, object val, Options opts, int depth)
         {
             var serializer = GetSemiStaticSerializerFor(val.GetType(), opts);
 
-            serializer(stream, val, depth);
+            serializer(dynamicMember, stream, val, depth);
         }
 
         static void SerializeList(TextWriter stream, IEnumerable e, Options opts, int depth)
@@ -730,6 +732,11 @@ namespace Jil.SerializeDynamic
         public static readonly MethodInfo SerializeMtd = typeof(DynamicSerializer).GetMethod("Serialize");
         public static void Serialize(TextWriter stream, object obj, Options opts, int depth)
         {
+            SerializeInternal(null, stream, obj, opts, depth);
+        }
+
+        public static readonly MethodInfo SerializeInternalMtd = typeof(DynamicSerializer).GetMethod("SerializeInternal", BindingFlags.NonPublic | BindingFlags.Static);
+        private static void SerializeInternal(MemberInfo dynamicMember, TextWriter stream, object obj, Options opts, int depth) { 
             if (obj == null)
             {
                 stream.Write("null");
@@ -814,7 +821,7 @@ namespace Jil.SerializeDynamic
                 return;
             }
 
-            SerializeSemiStatically(stream, obj, opts, depth);
+            SerializeSemiStatically(dynamicMember, stream, obj, opts, depth);
         }
     }
 }

--- a/JilTests/DeserializeTests.cs
+++ b/JilTests/DeserializeTests.cs
@@ -5940,6 +5940,133 @@ namespace JilTests
             }
         }
 
+        // Also see SeserializeTests._Issue150
+        class _Issue150
+        {
+            public enum A { A, B, C }
+
+            public class _InArray<T>
+            {
+                [JilDirective(TreatEnumerationAs = typeof(int))]
+                public T[] ArrayOfEnum = null;
+            }
+
+            public class _InList<T>
+            {
+                [JilDirective(TreatEnumerationAs = typeof(int))]
+                public List<T> ListOfEnum = null;
+            }
+
+            public class _InListProp<T>
+            {
+                [JilDirective(TreatEnumerationAs = typeof(int))]
+                public List<T> ListOfEnum { get; set; }
+            }
+
+            public class _InEnumerable<T>
+            {
+                [JilDirective(TreatEnumerationAs = typeof(int))]
+                public IEnumerable<T> EnumerableOfEnum = null;
+            }
+
+            public class _AsDictionaryKey<T>
+            {
+                [JilDirective(TreatEnumerationAs = typeof(int))]
+                public Dictionary<T, int> DictionaryWithEnumKey = null;
+            }
+
+            public class _AsDictionaryValue<T>
+            {
+                [JilDirective(TreatEnumerationAs = typeof(int))]
+                public Dictionary<int, T> DictionaryWithEnumValue = null;
+            }
+        }
+
+        [TestMethod]
+        public void Issue150()
+        {
+            {
+                var obj = JSON.Deserialize<_Issue150._InArray<_Issue150.A>>("{\"ArrayOfEnum\":[0,1]}");
+                CollectionAssert.AreEqual(new[] { _Issue150.A.A, _Issue150.A.B }, obj.ArrayOfEnum);
+            }
+
+            {
+                var obj = JSON.Deserialize<_Issue150._InArray<_Issue150.A?>>("{\"ArrayOfEnum\":[0,null]}");
+                CollectionAssert.AreEqual(new _Issue150.A?[] { _Issue150.A.A, null }, obj.ArrayOfEnum);
+            }
+
+            {
+                var obj = JSON.Deserialize<_Issue150._InList<_Issue150.A>>("{\"ListOfEnum\":[0,1]}");
+                CollectionAssert.AreEqual(new[] { _Issue150.A.A, _Issue150.A.B }, obj.ListOfEnum);
+            }
+
+            {
+                var obj = JSON.Deserialize<_Issue150._InList<_Issue150.A?>>("{\"ListOfEnum\":[0,null]}");
+                CollectionAssert.AreEqual(new _Issue150.A?[] { _Issue150.A.A, null }, obj.ListOfEnum);
+            }
+
+            {
+                var obj = JSON.Deserialize<_Issue150._InListProp<_Issue150.A>>("{\"ListOfEnum\":[0,1]}");
+                CollectionAssert.AreEqual(new[] { _Issue150.A.A, _Issue150.A.B }, obj.ListOfEnum);
+            }
+
+            {
+                var obj = JSON.Deserialize<_Issue150._InListProp<_Issue150.A?>>("{\"ListOfEnum\":[0,null]}");
+                CollectionAssert.AreEqual(new _Issue150.A?[] { _Issue150.A.A, null }, obj.ListOfEnum);
+            }
+
+            {
+                var obj = JSON.Deserialize<_Issue150._AsDictionaryKey<_Issue150.A>>("{\"DictionaryWithEnumKey\":{\"0\":10,\"1\":20}}");
+                CollectionAssert.AreEqual(new Dictionary<_Issue150.A, int>
+                {
+                    { _Issue150.A.A, 10 },
+                    { _Issue150.A.B, 20 }
+                }, obj.DictionaryWithEnumKey);
+            }
+
+            {
+                var obj = JSON.Deserialize<_Issue150._AsDictionaryValue<_Issue150.A>>("{\"DictionaryWithEnumValue\":{\"10\":0,\"20\":1}}");
+                CollectionAssert.AreEqual(new Dictionary<int, _Issue150.A>
+                {
+                    { 10, _Issue150.A.A },
+                    { 20, _Issue150.A.B }
+                }, obj.DictionaryWithEnumValue);
+            }
+
+            {
+                var obj = JSON.Deserialize<_Issue150._AsDictionaryValue<_Issue150.A?>>("{\"DictionaryWithEnumValue\":{\"10\":0,\"20\":null}}");
+                CollectionAssert.AreEqual(new Dictionary<int, _Issue150.A?>
+                {
+                    { 10, _Issue150.A.A },
+                    { 20, null }
+                }, obj.DictionaryWithEnumValue);
+            }
+        }
+
+        // Also see SeserializeTests._Issue151
+        class _Issue151
+        {
+            public enum A { A, B, C }
+
+            [JilDirective(TreatEnumerationAs = typeof(int))]
+            public A? NullableEnum = null;
+        }
+
+        [TestMethod]
+        public void Issue151()
+        {
+            {
+                var obj = JSON.Deserialize<_Issue151>("{\"NullableEnum\":1}");
+                Assert.IsTrue(obj.NullableEnum.HasValue);
+                Assert.AreEqual(_Issue151.A.B, obj.NullableEnum.Value);
+            }
+
+            {
+                var obj = JSON.Deserialize<_Issue151>("{\"NullableEnum\":null}");
+                Assert.IsFalse(obj.NullableEnum.HasValue);
+            }
+        }
+
 #if !DEBUG
         #region SlowSpinUp Types
 

--- a/JilTests/DynamicSerializationTests.cs
+++ b/JilTests/DynamicSerializationTests.cs
@@ -1202,6 +1202,12 @@ namespace JilTests
                 public List<T> ListOfEnum { get; set; }
             }
 
+            public class _InEnumerable<T>
+            {
+                [JilDirective(TreatEnumerationAs = typeof(int))]
+                public IEnumerable<T> EnumerableOfEnum;
+            }
+
             public class _AsDictionaryKey<T>
             {
                 [JilDirective(TreatEnumerationAs = typeof(int))]
@@ -1213,12 +1219,6 @@ namespace JilTests
                 [JilDirective(TreatEnumerationAs = typeof(int))]
                 public Dictionary<int, T> DictionaryWithEnumValue;
             }
-        }
-
-        class Test
-        {
-            [JilDirective(Name = "Other")]
-            public string MeepMeep { get; set; }
         }
 
         [TestMethod]
@@ -1270,6 +1270,22 @@ namespace JilTests
 
                 var str = JSON.SerializeDynamic(obj);
                 Assert.AreEqual("{\"ListOfEnum\":[0,null]}", str);
+            }
+
+            {
+                var obj = new _Issue150._InEnumerable<_Issue150.A>();
+                obj.EnumerableOfEnum = new HashSet<_Issue150.A> { _Issue150.A.A, _Issue150.A.B };
+
+                var str = JSON.SerializeDynamic(obj);
+                Assert.AreEqual("{\"EnumerableOfEnum\":[0,1]}", str);
+            }
+
+            {
+                var obj = new _Issue150._InEnumerable<_Issue150.A?>();
+                obj.EnumerableOfEnum = new HashSet<_Issue150.A?> { _Issue150.A.A, null };
+
+                var str = JSON.SerializeDynamic(obj);
+                Assert.AreEqual("{\"EnumerableOfEnum\":[0,null]}", str);
             }
 
             {

--- a/JilTests/DynamicSerializationTests.cs
+++ b/JilTests/DynamicSerializationTests.cs
@@ -1178,5 +1178,164 @@ namespace JilTests
                 Assert.AreEqual("{\"Foo\":{\"Bar\":{\"Foo\":null}}}", res);
             }
         }
+
+        // Also see DeserializeDynamicTests._Issue150
+        class _Issue150
+        {
+            public enum A { A, B, C }
+
+            public class _InArray<T>
+            {
+                [JilDirective(TreatEnumerationAs = typeof(int))]
+                public T[] ArrayOfEnum;
+            }
+
+            public class _InList<T>
+            {
+                [JilDirective(TreatEnumerationAs = typeof(int))]
+                public List<T> ListOfEnum;
+            }
+
+            public class _InListProp<T>
+            {
+                [JilDirective(TreatEnumerationAs = typeof(int))]
+                public List<T> ListOfEnum { get; set; }
+            }
+
+            public class _AsDictionaryKey<T>
+            {
+                [JilDirective(TreatEnumerationAs = typeof(int))]
+                public Dictionary<T, int> DictionaryWithEnumKey;
+            }
+
+            public class _AsDictionaryValue<T>
+            {
+                [JilDirective(TreatEnumerationAs = typeof(int))]
+                public Dictionary<int, T> DictionaryWithEnumValue;
+            }
+        }
+
+        class Test
+        {
+            [JilDirective(Name = "Other")]
+            public string MeepMeep { get; set; }
+        }
+
+        [TestMethod]
+        public void Issue150()
+        {
+            {
+                var obj = new _Issue150._InArray<_Issue150.A>();
+                obj.ArrayOfEnum = new[] { _Issue150.A.A, _Issue150.A.B };
+
+                var str = JSON.SerializeDynamic(obj);
+                Assert.AreEqual("{\"ArrayOfEnum\":[0,1]}", str);
+            }
+
+            {
+                var obj = new _Issue150._InArray<_Issue150.A?>();
+                obj.ArrayOfEnum = new _Issue150.A?[] { _Issue150.A.A, null };
+
+                var str = JSON.SerializeDynamic(obj);
+                Assert.AreEqual("{\"ArrayOfEnum\":[0,null]}", str);
+            }
+
+            {
+                var obj = new _Issue150._InList<_Issue150.A>();
+                obj.ListOfEnum = new List<_Issue150.A>(new[] { _Issue150.A.A, _Issue150.A.B });
+
+                var str = JSON.SerializeDynamic(obj);
+                Assert.AreEqual("{\"ListOfEnum\":[0,1]}", str);
+            }
+
+            {
+                var obj = new _Issue150._InList<_Issue150.A?>();
+                obj.ListOfEnum = new List<_Issue150.A?>(new _Issue150.A?[] { _Issue150.A.A, null });
+
+                var str = JSON.SerializeDynamic(obj);
+                Assert.AreEqual("{\"ListOfEnum\":[0,null]}", str);
+            }
+
+            {
+                var obj = new _Issue150._InListProp<_Issue150.A>();
+                obj.ListOfEnum = new List<_Issue150.A>(new[] { _Issue150.A.A, _Issue150.A.B });
+
+                var str = JSON.SerializeDynamic(obj);
+                Assert.AreEqual("{\"ListOfEnum\":[0,1]}", str);
+            }
+
+            {
+                var obj = new _Issue150._InListProp<_Issue150.A?>();
+                obj.ListOfEnum = new List<_Issue150.A?>(new _Issue150.A?[] { _Issue150.A.A, null });
+
+                var str = JSON.SerializeDynamic(obj);
+                Assert.AreEqual("{\"ListOfEnum\":[0,null]}", str);
+            }
+
+            {
+                var obj = new _Issue150._AsDictionaryKey<_Issue150.A>();
+                obj.DictionaryWithEnumKey = new Dictionary<_Issue150.A, int>
+                {
+                    { _Issue150.A.A, 10 },
+                    { _Issue150.A.B, 20 }
+                };
+
+                var str = JSON.SerializeDynamic(obj);
+                Assert.AreEqual("{\"DictionaryWithEnumKey\":{\"0\":10,\"1\":20}}", str);
+            }
+
+            {
+                var obj = new _Issue150._AsDictionaryValue<_Issue150.A>();
+                obj.DictionaryWithEnumValue = new Dictionary<int, _Issue150.A>
+                {
+                    { 10, _Issue150.A.A },
+                    { 20, _Issue150.A.B }
+                };
+
+                var str = JSON.SerializeDynamic(obj);
+                Assert.AreEqual("{\"DictionaryWithEnumValue\":{\"10\":0,\"20\":1}}", str);
+            }
+
+            {
+                var obj = new _Issue150._AsDictionaryValue<_Issue150.A?>();
+                obj.DictionaryWithEnumValue = new Dictionary<int, _Issue150.A?>
+                {
+                    { 10, _Issue150.A.A },
+                    { 20, null }
+                };
+
+                var str = JSON.SerializeDynamic(obj);
+                Assert.AreEqual("{\"DictionaryWithEnumValue\":{\"10\":0,\"20\":null}}", str);
+            }
+        }
+
+        // Also see DeserializeDynamicTests._Issue151
+        class _Issue151
+        {
+            public enum A { A, B, C }
+
+            [JilDirective(TreatEnumerationAs = typeof(int))]
+            public A? NullableEnum;
+        }
+
+        [TestMethod]
+        public void Issue151()
+        {
+            {
+                var obj = new _Issue151();
+                obj.NullableEnum = _Issue151.A.B;
+
+                var str = JSON.SerializeDynamic(obj);
+                Assert.AreEqual("{\"NullableEnum\":1}", str);
+            }
+
+            {
+                var obj = new _Issue151();
+                obj.NullableEnum = null;
+
+                var str = JSON.SerializeDynamic(obj);
+                Assert.AreEqual("{\"NullableEnum\":null}", str);
+            }
+        }
     }
 }

--- a/JilTests/DynamicSerializationTests.cs
+++ b/JilTests/DynamicSerializationTests.cs
@@ -1219,6 +1219,12 @@ namespace JilTests
                 [JilDirective(TreatEnumerationAs = typeof(int))]
                 public Dictionary<int, T> DictionaryWithEnumValue;
             }
+
+            public class _MultipleLists<T> {
+                [JilDirective(TreatEnumerationAs = typeof(int))]
+                public List<T> List1;
+                public List<T> List2;
+            }
         }
 
         [TestMethod]
@@ -1322,6 +1328,15 @@ namespace JilTests
 
                 var str = JSON.SerializeDynamic(obj);
                 Assert.AreEqual("{\"DictionaryWithEnumValue\":{\"10\":0,\"20\":null}}", str);
+            }
+
+            {
+                var obj = new _Issue150._MultipleLists<_Issue150.A>();
+                obj.List1 = new List<_Issue150.A>(new[] { _Issue150.A.A, _Issue150.A.B });
+                obj.List2 = new List<_Issue150.A>(new[] { _Issue150.A.A, _Issue150.A.B });
+
+                var str = JSON.SerializeDynamic(obj);
+                Assert.AreEqual("{\"List1\":[0,1],\"List2\":[\"A\",\"B\"]}", str);
             }
         }
 

--- a/JilTests/SerializeTests.cs
+++ b/JilTests/SerializeTests.cs
@@ -8020,6 +8020,18 @@ namespace JilTests
                 public List<T> ListOfEnum;
             }
 
+            public class _InListProp<T>
+            {
+                [JilDirective(TreatEnumerationAs = typeof(int))]
+                public List<T> ListOfEnum { get; set; }
+            }
+
+            public class _InEnumerable<T>
+            {
+                [JilDirective(TreatEnumerationAs = typeof(int))]
+                public IEnumerable<T> EnumerableOfEnum;
+            }
+
             public class _AsDictionaryKey<T>
             {
                 [JilDirective(TreatEnumerationAs = typeof(int))]
@@ -8066,6 +8078,38 @@ namespace JilTests
 
                 var str = JSON.Serialize(obj);
                 Assert.AreEqual("{\"ListOfEnum\":[0,null]}", str);
+            }
+
+            {
+                var obj = new _Issue150._InListProp<_Issue150.A>();
+                obj.ListOfEnum = new List<_Issue150.A>(new[] { _Issue150.A.A, _Issue150.A.B });
+
+                var str = JSON.Serialize(obj);
+                Assert.AreEqual("{\"ListOfEnum\":[0,1]}", str);
+            }
+
+            {
+                var obj = new _Issue150._InListProp<_Issue150.A?>();
+                obj.ListOfEnum = new List<_Issue150.A?>(new _Issue150.A?[] { _Issue150.A.A, null });
+
+                var str = JSON.Serialize(obj);
+                Assert.AreEqual("{\"ListOfEnum\":[0,null]}", str);
+            }
+
+            {
+                var obj = new _Issue150._InEnumerable<_Issue150.A>();
+                obj.EnumerableOfEnum = new HashSet<_Issue150.A> { _Issue150.A.A, _Issue150.A.B };
+
+                var str = JSON.Serialize(obj);
+                Assert.AreEqual("{\"EnumerableOfEnum\":[0,1]}", str);
+            }
+
+            {
+                var obj = new _Issue150._InEnumerable<_Issue150.A?>();
+                obj.EnumerableOfEnum = new HashSet<_Issue150.A?> { _Issue150.A.A, null };
+
+                var str = JSON.Serialize(obj);
+                Assert.AreEqual("{\"EnumerableOfEnum\":[0,null]}", str);
             }
 
             {

--- a/JilTests/SerializeTests.cs
+++ b/JilTests/SerializeTests.cs
@@ -8002,5 +8002,136 @@ namespace JilTests
             res = JSON.Serialize(int.MinValue);
             Assert.AreEqual("-2147483648", res);
         }
+
+        // Also see DeserializeTests._Issue150
+        class _Issue150
+        {
+            public enum A { A, B, C }
+
+            public class _InArray<T>
+            {
+                [JilDirective(TreatEnumerationAs = typeof(int))]
+                public T[] ArrayOfEnum;
+            }
+
+            public class _InList<T>
+            {
+                [JilDirective(TreatEnumerationAs = typeof(int))]
+                public List<T> ListOfEnum;
+            }
+
+            public class _AsDictionaryKey<T>
+            {
+                [JilDirective(TreatEnumerationAs = typeof(int))]
+                public Dictionary<T, int> DictionaryWithEnumKey;
+            }
+
+            public class _AsDictionaryValue<T>
+            {
+                [JilDirective(TreatEnumerationAs = typeof(int))]
+                public Dictionary<int, T> DictionaryWithEnumValue;
+            }
+        }
+
+        [TestMethod]
+        public void Issue150()
+        {
+            {
+                var obj = new _Issue150._InArray<_Issue150.A>();
+                obj.ArrayOfEnum = new[] { _Issue150.A.A, _Issue150.A.B };
+
+                var str = JSON.Serialize(obj);
+                Assert.AreEqual("{\"ArrayOfEnum\":[0,1]}", str);
+            }
+
+            {
+                var obj = new _Issue150._InArray<_Issue150.A?>();
+                obj.ArrayOfEnum = new _Issue150.A?[] { _Issue150.A.A, null };
+
+                var str = JSON.Serialize(obj);
+                Assert.AreEqual("{\"ArrayOfEnum\":[0,null]}", str);
+            }
+
+            {
+                var obj = new _Issue150._InList<_Issue150.A>();
+                obj.ListOfEnum = new List<_Issue150.A>(new[] { _Issue150.A.A, _Issue150.A.B });
+
+                var str = JSON.Serialize(obj);
+                Assert.AreEqual("{\"ListOfEnum\":[0,1]}", str);
+            }
+
+            {
+                var obj = new _Issue150._InList<_Issue150.A?>();
+                obj.ListOfEnum = new List<_Issue150.A?>(new _Issue150.A?[] { _Issue150.A.A, null });
+
+                var str = JSON.Serialize(obj);
+                Assert.AreEqual("{\"ListOfEnum\":[0,null]}", str);
+            }
+
+            {
+                var obj = new _Issue150._AsDictionaryKey<_Issue150.A>();
+                obj.DictionaryWithEnumKey = new Dictionary<_Issue150.A, int>
+                {
+                    { _Issue150.A.A, 10 },
+                    { _Issue150.A.B, 20 }
+                };
+
+                var str = JSON.Serialize(obj);
+                Assert.AreEqual("{\"DictionaryWithEnumKey\":{\"0\":10,\"1\":20}}", str);
+            }
+
+            {
+                var obj = new _Issue150._AsDictionaryValue<_Issue150.A>();
+                obj.DictionaryWithEnumValue = new Dictionary<int, _Issue150.A>
+                {
+                    { 10, _Issue150.A.A },
+                    { 20, _Issue150.A.B }
+                };
+
+                var str = JSON.Serialize(obj);
+                Assert.AreEqual("{\"DictionaryWithEnumValue\":{\"10\":0,\"20\":1}}", str);
+            }
+
+            {
+                var obj = new _Issue150._AsDictionaryValue<_Issue150.A?>();
+                obj.DictionaryWithEnumValue = new Dictionary<int, _Issue150.A?>
+                {
+                    { 10, _Issue150.A.A },
+                    { 20, null }
+                };
+
+                var str = JSON.Serialize(obj);
+                Assert.AreEqual("{\"DictionaryWithEnumValue\":{\"10\":0,\"20\":null}}", str);
+            }
+        }
+
+        // Also see DeserializeTests._Issue151
+        class _Issue151
+        {
+            public enum A { A, B, C }
+
+            [JilDirective(TreatEnumerationAs = typeof(int))]
+            public A? NullableEnum;
+        }
+
+        [TestMethod]
+        public void Issue151()
+        {
+            {
+                var obj = new _Issue151();
+                obj.NullableEnum = _Issue151.A.B;
+
+                var str = JSON.Serialize(obj);
+                Assert.AreEqual("{\"NullableEnum\":1}", str);
+            }
+
+            {
+                var obj = new _Issue151();
+                obj.NullableEnum = null;
+
+                var str = JSON.Serialize(obj);
+                Assert.AreEqual("{\"NullableEnum\":null}", str);
+            }
+        }
     }
 }


### PR DESCRIPTION
This pull request fixes #150 and #151.

Most of the Write* methods in the `InlineSerializer` now take a `MemberInfo` containing information about the member they're writing the value of, when there's no member (e.g. root of the object graph, then this value will be `null`.)

The dynamic part was a little harder, seeing as it tries to semi-statically parse known types. The dynamic call out will now calls an internal `SerializeInternal` method of the `DynamicSerializer` class that takes a `MemberInfo`.

Currently applies the `TreatEnumerationAs` on the following items:
- Items in Arrays
- Items in Lists
- Items in an IEnumerable
- Dictionary keys and values