### PR TITLE
Cache char[] instances

### DIFF
--- a/Benchmark/ExtensionMethods.cs
+++ b/Benchmark/ExtensionMethods.cs
@@ -14,22 +14,12 @@ namespace Benchmark
 
     static class ExtensionMethods
     {
-        static readonly char[] ASCII;
-
-        static ExtensionMethods()
-        {
-            var cs = new List<char>();
-
-            for (var i = 0; i <= byte.MaxValue; i++)
-            {
-                var c = (char)i;
-                if (char.IsControl(c)) continue;
-
-                cs.Add(c);
-            }
-
-            ASCII = cs.ToArray();
-        }
+        static readonly char[] ASCII =
+            Enumerable
+            .Range(0, byte.MaxValue)
+            .Select(b => (char)b)
+            .Where(c => !Char.IsControl(c))
+            .ToArray();
 
         public static bool TrueEqualsDictionary<K, V>(this Dictionary<K, V> a, Dictionary<K, V> b)
             where V : class, IGenericEquality<V>

--- a/Benchmark/Result.cs
+++ b/Benchmark/Result.cs
@@ -11,5 +11,6 @@ namespace Benchmark
         public string Serializer { get; set; }
         public string TypeName { get; set; }
         public TimeSpan Elapsed { get; set; }
+        public int[] GCCounts { get; set; }
     }
 }

--- a/Jil/Serialize/Methods.Get.cs
+++ b/Jil/Serialize/Methods.Get.cs
@@ -9,6 +9,12 @@ namespace Jil.Serialize
 {
     static partial class Methods
     {
+        public static MethodInfo GetCachedCharBuffer()
+        {
+            // no difference depending on thunk writer here
+            return GetThreadLocalCharBuffer;
+        }
+
         public static MethodInfo GetValidateDouble()
         {
             // no difference depending on thunk writer here

--- a/Jil/Serialize/Methods.ThunkWriter.cs
+++ b/Jil/Serialize/Methods.ThunkWriter.cs
@@ -782,7 +782,7 @@ namespace Jil.Serialize
                 return;
             }
 
-            var ptr = InlineSerializer<object>.CharBufferSize - 1;
+            var ptr = InlineSerializer.CharBufferSize - 1;
 
             uint copy;
             if (number < 0)
@@ -810,7 +810,7 @@ namespace Jil.Serialize
                 ptr++;
             }
 
-            writer.Write(buffer, ptr + 1, InlineSerializer<object>.CharBufferSize - 1 - ptr);
+            writer.Write(buffer, ptr + 1, InlineSerializer.CharBufferSize - 1 - ptr);
         }
 
         static readonly MethodInfo CustomWriteIntUnrolledSigned_ThunkWriter = typeof(Methods).GetMethod("_CustomWriteIntUnrolledSigned_ThunkWriter", BindingFlags.Static | BindingFlags.NonPublic);
@@ -970,7 +970,7 @@ namespace Jil.Serialize
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static void _CustomWriteUInt_ThunkWriter(ref ThunkWriter writer, uint number, char[] buffer)
         {
-            var ptr = InlineSerializer<object>.CharBufferSize - 1;
+            var ptr = InlineSerializer.CharBufferSize - 1;
 
             var copy = number;
 
@@ -989,7 +989,7 @@ namespace Jil.Serialize
                 ptr++;
             }
 
-            writer.Write(buffer, ptr + 1, InlineSerializer<object>.CharBufferSize - 1 - ptr);
+            writer.Write(buffer, ptr + 1, InlineSerializer.CharBufferSize - 1 - ptr);
         }
 
         static readonly MethodInfo CustomWriteUIntUnrolled_ThunkWriter = typeof(Methods).GetMethod("_CustomWriteUIntUnrolled_ThunkWriter", BindingFlags.Static | BindingFlags.NonPublic);
@@ -1109,7 +1109,7 @@ namespace Jil.Serialize
                 return;
             }
 
-            var ptr = InlineSerializer<object>.CharBufferSize - 1;
+            var ptr = InlineSerializer.CharBufferSize - 1;
 
             ulong copy;
             if (number < 0)
@@ -1137,14 +1137,14 @@ namespace Jil.Serialize
                 ptr++;
             }
 
-            writer.Write(buffer, ptr + 1, InlineSerializer<object>.CharBufferSize - 1 - ptr);
+            writer.Write(buffer, ptr + 1, InlineSerializer.CharBufferSize - 1 - ptr);
         }
 
         static readonly MethodInfo CustomWriteULong_ThunkWriter = typeof(Methods).GetMethod("_CustomWriteULong_ThunkWriter", BindingFlags.Static | BindingFlags.NonPublic);
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static void _CustomWriteULong_ThunkWriter(ref ThunkWriter writer, ulong number, char[] buffer)
         {
-            var ptr = InlineSerializer<object>.CharBufferSize - 1;
+            var ptr = InlineSerializer.CharBufferSize - 1;
 
             var copy = number;
 
@@ -1163,7 +1163,7 @@ namespace Jil.Serialize
                 ptr++;
             }
 
-            writer.Write(buffer, ptr + 1, InlineSerializer<object>.CharBufferSize - 1 - ptr);
+            writer.Write(buffer, ptr + 1, InlineSerializer.CharBufferSize - 1 - ptr);
         }
 
         static readonly MethodInfo ProxyFloat_ThunkWriter = typeof(Methods).GetMethod("_ProxyFloat_ThunkWriter", BindingFlags.Static | BindingFlags.NonPublic);

--- a/Jil/Serialize/Methods.cs
+++ b/Jil/Serialize/Methods.cs
@@ -6,13 +6,30 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
+using System.Threading;
 
 namespace Jil.Serialize
 {
     static partial class Methods
     {
+        /// <summary>
+        /// Thread-local, cached character buffers.
+        /// </summary>
+        /// <remarks>
+        /// Caching the character buffers improves performance by avoiding allocation
+        /// (and subsequent collection) of a short-lived array each time an instance/value
+        /// of a primitive type is serialized.
+        /// </remarks>
+        [ThreadStatic]
+        private static char[] _threadLocalCharBuffer;
+
+        static readonly MethodInfo GetThreadLocalCharBuffer = typeof(Methods).GetMethod("_GetThreadLocalCharBuffer", BindingFlags.Static | BindingFlags.NonPublic);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static char[] _GetThreadLocalCharBuffer()
+        {
+            return _threadLocalCharBuffer ?? (_threadLocalCharBuffer = new char[InlineSerializer.CharBufferSize]);
+        }
+
         struct TwoDigits
         {
             public readonly char First;
@@ -866,7 +883,7 @@ namespace Jil.Serialize
                 return;
             }
 
-            var ptr = InlineSerializer<object>.CharBufferSize - 1;
+            var ptr = InlineSerializer.CharBufferSize - 1;
 
             uint copy;
             if (number < 0)
@@ -894,7 +911,7 @@ namespace Jil.Serialize
                 ptr++;
             }
 
-            writer.Write(buffer, ptr + 1, InlineSerializer<object>.CharBufferSize - 1 - ptr);
+            writer.Write(buffer, ptr + 1, InlineSerializer.CharBufferSize - 1 - ptr);
         }
 
         static readonly MethodInfo CustomWriteIntUnrolledSigned = typeof(Methods).GetMethod("_CustomWriteIntUnrolledSigned", BindingFlags.Static | BindingFlags.NonPublic);
@@ -1054,7 +1071,7 @@ namespace Jil.Serialize
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static void _CustomWriteUInt(TextWriter writer, uint number, char[] buffer)
         {
-            var ptr = InlineSerializer<object>.CharBufferSize - 1;
+            var ptr = InlineSerializer.CharBufferSize - 1;
 
             var copy = number;
 
@@ -1073,7 +1090,7 @@ namespace Jil.Serialize
                 ptr++;
             }
 
-            writer.Write(buffer, ptr + 1, InlineSerializer<object>.CharBufferSize - 1 - ptr);
+            writer.Write(buffer, ptr + 1, InlineSerializer.CharBufferSize - 1 - ptr);
         }
 
         static readonly MethodInfo CustomWriteUIntUnrolled = typeof(Methods).GetMethod("_CustomWriteUIntUnrolled", BindingFlags.Static | BindingFlags.NonPublic);
@@ -1193,7 +1210,7 @@ namespace Jil.Serialize
                 return;
             }
 
-            var ptr = InlineSerializer<object>.CharBufferSize - 1;
+            var ptr = InlineSerializer.CharBufferSize - 1;
 
             ulong copy;
             if (number < 0)
@@ -1221,14 +1238,14 @@ namespace Jil.Serialize
                 ptr++;
             }
 
-            writer.Write(buffer, ptr + 1, InlineSerializer<object>.CharBufferSize - 1 - ptr);
+            writer.Write(buffer, ptr + 1, InlineSerializer.CharBufferSize - 1 - ptr);
         }
         
         static readonly MethodInfo CustomWriteULong = typeof(Methods).GetMethod("_CustomWriteULong", BindingFlags.Static | BindingFlags.NonPublic);
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static void _CustomWriteULong(TextWriter writer, ulong number, char[] buffer)
         {
-            var ptr = InlineSerializer<object>.CharBufferSize - 1;
+            var ptr = InlineSerializer.CharBufferSize - 1;
 
             var copy = number;
 
@@ -1247,7 +1264,7 @@ namespace Jil.Serialize
                 ptr++;
             }
 
-            writer.Write(buffer, ptr + 1, InlineSerializer<object>.CharBufferSize - 1 - ptr);
+            writer.Write(buffer, ptr + 1, InlineSerializer.CharBufferSize - 1 - ptr);
         }
 
         static readonly MethodInfo ProxyFloat = typeof(Methods).GetMethod("_ProxyFloat", BindingFlags.Static | BindingFlags.NonPublic);


### PR DESCRIPTION
I've made some small modifications to cache ``char[]`` instances in a thread-local variable instead of re-allocating them each time one is needed (e.g., to serialize a ``DateTime`` to ISO8601 format). Running the "quick graph" mode of the benchmark tool didn't show any real difference (better or worse), but it seems better to have fewer allocations/GCs if possible to avoid impacting other code in the process.