### PR TITLE
Eliminate static constructor (cctor) in Methods class

### DIFF
--- a/Jil/Common/Utils.cs
+++ b/Jil/Common/Utils.cs
@@ -1298,5 +1298,35 @@ namespace Jil.Common
                 return PowersOf10[power];
             return (long)Math.Pow(10, power);
         }
+
+        /// <summary>
+        /// Functional-style helper method for creating and initializing a new array.
+        /// </summary>
+        /// <typeparam name="T">The element type of the array.</typeparam>
+        /// <param name="count">The length of the array to create.</param>
+        /// <param name="generator">
+        /// The function used to initialize each element of the array.
+        /// The integer applied to the function represents the index of the element being initialized.
+        /// </param>
+        /// <returns>An array with element type <typeparamref>T</typeparamref> and length <paramref>count</paramref>.</returns>
+        internal static T[] CreateArray<T>(int count, Func<int, T> generator)
+        {
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException("count");
+            }
+            else if (generator == null)
+            {
+                throw new ArgumentNullException("generator");
+            }
+            //Contract.EndContractBlock();
+
+            var arr = new T[count];
+            for (var i = 0; i < arr.Length; i++)
+            {
+                arr[i] = generator(i);
+            }
+            return arr;
+        }
     }
 }

--- a/Jil/Serialize/Methods.cs
+++ b/Jil/Serialize/Methods.cs
@@ -25,24 +25,23 @@ namespace Jil.Serialize
             }
         }
 
-        private static readonly TwoDigits[] DigitPairs;
-        private static readonly char[] DigitTriplets;
-        static Methods()
-        {
-            DigitPairs = new TwoDigits[100];
-            for (var i = 0; i < 100; ++i)
-            {
-                DigitPairs[i] = new TwoDigits((char)('0' + (i / 10)), (char)+('0' + (i % 10)));
-            }
-
-            DigitTriplets = new char[1000 * 3];
-            for (var i = 0; i < 1000; ++i)
-            {
-                DigitTriplets[i * 3 + 0] = (char)('0' + i / 100 % 10);
-                DigitTriplets[i * 3 + 1] = (char)('0' + i / 10 % 10);
-                DigitTriplets[i * 3 + 2] = (char)('0' + i % 10);
-            }
-        }
+        private static readonly TwoDigits[] DigitPairs =
+            Common.Utils.CreateArray(100, i => new TwoDigits((char)('0' + (i / 10)), (char)+('0' + (i % 10))));
+        private static readonly char[] DigitTriplets =
+            Common.Utils.CreateArray(3 * 1000, i =>
+	    {
+	        switch (i % 3)
+		{
+		    case 0:
+		        return (char)('0' + i / 100 % 10);
+                    case 1:
+		        return (char)('0' + i / 10 % 10);
+                    case 2:
+		        return (char)('0' + i % 10);
+                    default:
+		        throw new InvalidOperationException("Unexpectedly reached default case in switch block.");
+                }
+            });
 
         [StructLayout(LayoutKind.Explicit, Pack = 1)]
         struct GuidStruct

--- a/Jil/Serialize/Methods.cs
+++ b/Jil/Serialize/Methods.cs
@@ -29,17 +29,18 @@ namespace Jil.Serialize
             Common.Utils.CreateArray(100, i => new TwoDigits((char)('0' + (i / 10)), (char)+('0' + (i % 10))));
         private static readonly char[] DigitTriplets =
             Common.Utils.CreateArray(3 * 1000, i =>
-	    {
-	        switch (i % 3)
-		{
-		    case 0:
-		        return (char)('0' + i / 100 % 10);
+            {
+                var ibase = i / 3;
+                switch (i % 3)
+                {
+                    case 0:
+                        return (char)('0' + ibase / 100 % 10);
                     case 1:
-		        return (char)('0' + i / 10 % 10);
+                        return (char)('0' + ibase / 10 % 10);
                     case 2:
-		        return (char)('0' + i % 10);
+                        return (char)('0' + ibase % 10);
                     default:
-		        throw new InvalidOperationException("Unexpectedly reached default case in switch block.");
+                        throw new InvalidOperationException("Unexpectedly reached default case in switch block.");
                 }
             });
 


### PR DESCRIPTION
I've modified the way the ``DigitPairs`` and ``DigitTriplets`` fields are initialized in the ``Methods`` class to avoid using a static constructor. Using a static ctor causes the CLR JIT to have to inject initialization-checking thunks into the static methods of the class (to check if the class has been initialized); in many cases, removing the static ctor allows the ``.beforefieldinit`` flag to be applied to the class so the CLR can elide the initialization checks.

More info: [CA1810: Initialize reference type static fields inline](https://msdn.microsoft.com/en-us/library/ms182275.aspx)