### PR TITLE
JsonObject.InnerTryConvert() bug when returnType is Dictionary

### DIFF
--- a/Jil/DeserializeDynamic/JsonObject.Dynamic.cs
+++ b/Jil/DeserializeDynamic/JsonObject.Dynamic.cs
@@ -1342,8 +1342,8 @@ namespace Jil.DeserializeDynamic
                         var coerced = new Dictionary<object, object>(ObjectMembers.Count);
                         foreach (var kv in ObjectMembers)
                         {
-                            object innerResult;
-                            if (!kv.Value.InnerTryConvert(valType, out innerResult))
+                            object innerResult = null;
+                            if (kv.Value != null && !kv.Value.InnerTryConvert(valType, out innerResult))
                             {
                                 result = null;
                                 return false;

--- a/JilTests/DeserializeDynamicTests.cs
+++ b/JilTests/DeserializeDynamicTests.cs
@@ -2737,14 +2737,15 @@ namespace JilTests
 
             // Dictionary<string, dynamic>
             {
-                var dyn = JSON.DeserializeDynamic("{\"hello\":123, \"world\": 456.7 }");
+                var dyn = JSON.DeserializeDynamic("{\"hello\":123, \"world\": 456.7, \"goodbye\": null }");
                 System.ComponentModel.TypeConverter tc = System.ComponentModel.TypeDescriptor.GetConverter(dyn);
 
                 Assert.IsTrue(tc.CanConvertTo(typeof(IDictionary<string, dynamic>)));
                 var d = (Dictionary<string, dynamic>)tc.ConvertTo(dyn, typeof(IDictionary<string, dynamic>));
-                Assert.AreEqual(2, d.Count);
-                Assert.IsTrue(d.ContainsKey("hello"));
+                Assert.AreEqual(3, d.Count);
+                Assert.IsTrue(d.ContainsKey("hello"));                
                 Assert.IsTrue(d.ContainsKey("world"));
+                Assert.IsTrue(d.ContainsKey("goodbye"));
 
                 tc = System.ComponentModel.TypeDescriptor.GetConverter(d["hello"]);
                 Assert.IsTrue(tc.CanConvertTo(typeof(int)));
@@ -2753,6 +2754,8 @@ namespace JilTests
                 tc = System.ComponentModel.TypeDescriptor.GetConverter(d["world"]);
                 Assert.IsTrue(tc.CanConvertTo(typeof(double)));
                 Assert.AreEqual(456.7, (double)tc.ConvertTo(d["world"], typeof(double)));
+
+                Assert.IsNull((d["goodbye"]));
             }
 
             // Dictionary<enum, dynamic>


### PR DESCRIPTION
I made a small change to JsonObject.InnerTryConvert(), to handle the case when returnType is Dictionary, and the Dictionary contains a null value. 