### PR TITLE
Fixed InvalidCastException issue with deserializing certain Flags Enums

### DIFF
--- a/Jil/Deserialize/EnumLookup.cs
+++ b/Jil/Deserialize/EnumLookup.cs
@@ -129,7 +129,7 @@ namespace Jil.Deserialize
                     emit =>
                     {
                         emit.DeclareLocal(underlyingType, resultValue);
-                        LoadConstantOfType(emit, 0, underlyingType);
+                        LoadConstantOfType(emit, Convert.ChangeType(0, underlyingType), underlyingType);
                         emit.StoreLocal(resultValue);
                     },
                     emit =>
@@ -177,7 +177,7 @@ namespace Jil.Deserialize
                     emit =>
                     {
                         emit.DeclareLocal(underlyingType, resultValue);
-                        LoadConstantOfType(emit, 0, underlyingType);
+                        LoadConstantOfType(emit, Convert.ChangeType(0, underlyingType), underlyingType);
                         emit.StoreLocal(resultValue);
                     },
                     emit =>
@@ -196,27 +196,25 @@ namespace Jil.Deserialize
 
         static void LoadConstantOfType(Emit Emit, object val, Type type)
         {
-            dynamic dynamicVal = (dynamic) val;
-
             if (type == typeof(byte))
             {
-                Emit.LoadConstant((byte)dynamicVal);
+                Emit.LoadConstant((byte)val);
             }
             else if (type == typeof(sbyte))
             {
-                Emit.LoadConstant((sbyte)dynamicVal);
+                Emit.LoadConstant((sbyte)val);
             }
             else if (type == typeof(short))
             {
-                Emit.LoadConstant((short)dynamicVal);
+                Emit.LoadConstant((short)val);
             }
             else if (type == typeof(ushort))
             {
-                Emit.LoadConstant((ushort)dynamicVal);
+                Emit.LoadConstant((ushort)val);
             }
             else if (type == typeof(int))
             {
-                Emit.LoadConstant((int)dynamicVal);
+                Emit.LoadConstant((int)val);
             }
             else if (type == typeof(uint))
             {
@@ -224,11 +222,11 @@ namespace Jil.Deserialize
             }
             else if (type == typeof(long))
             {
-                Emit.LoadConstant((long)dynamicVal);
+                Emit.LoadConstant((long)val);
             }
             else if (type == typeof(ulong))
             {
-                Emit.LoadConstant((ulong)dynamicVal);
+                Emit.LoadConstant((ulong)val);
             }
             else
             {

--- a/Jil/Deserialize/EnumLookup.cs
+++ b/Jil/Deserialize/EnumLookup.cs
@@ -196,25 +196,27 @@ namespace Jil.Deserialize
 
         static void LoadConstantOfType(Emit Emit, object val, Type type)
         {
+            dynamic dynamicVal = (dynamic) val;
+
             if (type == typeof(byte))
             {
-                Emit.LoadConstant((byte)val);
+                Emit.LoadConstant((byte)dynamicVal);
             }
             else if (type == typeof(sbyte))
             {
-                Emit.LoadConstant((sbyte)val);
+                Emit.LoadConstant((sbyte)dynamicVal);
             }
             else if (type == typeof(short))
             {
-                Emit.LoadConstant((short)val);
+                Emit.LoadConstant((short)dynamicVal);
             }
             else if (type == typeof(ushort))
             {
-                Emit.LoadConstant((ushort)val);
+                Emit.LoadConstant((ushort)dynamicVal);
             }
             else if (type == typeof(int))
             {
-                Emit.LoadConstant((int)val);
+                Emit.LoadConstant((int)dynamicVal);
             }
             else if (type == typeof(uint))
             {
@@ -222,11 +224,11 @@ namespace Jil.Deserialize
             }
             else if (type == typeof(long))
             {
-                Emit.LoadConstant((long)val);
+                Emit.LoadConstant((long)dynamicVal);
             }
             else if (type == typeof(ulong))
             {
-                Emit.LoadConstant((ulong)val);
+                Emit.LoadConstant((ulong)dynamicVal);
             }
             else
             {

--- a/JilTests/EnumFlagsTest.cs
+++ b/JilTests/EnumFlagsTest.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Jil;
+using JilTests.Hashbrowns.Shared.Enums;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace JilTests
+{
+    using System;
+
+    namespace Hashbrowns.Shared.Enums
+    {
+        [Flags]
+        public enum APIRoles : byte
+        {
+            None = 0,
+            Trial = 1,
+            Tier1 = Trial | 2,
+            Tier2 = Tier1 | 4,
+            Tier3 = Tier2 | 8,
+            AllRoles = 255
+        }
+    }
+
+    [TestClass]
+    public class EnumFlagsTest
+    {
+        [TestMethod]
+        public void TestEnumFlagsSerialize()
+        {
+            APIRoles roles = APIRoles.AllRoles;
+
+            string data = JSON.Serialize(roles);
+
+            Assert.AreEqual(data, "\"Trial,Tier1,Tier2,Tier3,AllRoles\"");
+        }
+
+        [TestMethod]
+        public void TestEnumFlagsDeserialize()
+        {
+            APIRoles roles;
+
+            string data = "\"Trial,Tier1,Tier2,Tier3,AllRoles\"";
+
+            roles = JSON.Deserialize<APIRoles>(data);
+
+            Assert.AreEqual(roles, APIRoles.AllRoles);
+        }
+
+        [TestMethod]
+        public void TestEnumFlagsDeserialize2()
+        {
+            APIRoles roles;
+
+            string data = "\"AllRoles\"";
+
+            roles = JSON.Deserialize<APIRoles>(data);
+
+            Assert.AreEqual(roles, APIRoles.AllRoles);
+        }
+
+        [TestMethod]
+        public void TestEnumFlagsDeserialize3()
+        {
+            APIRoles roles;
+
+            string data = "\"None, Tier2\"";
+
+            roles = JSON.Deserialize<APIRoles>(data);
+
+            Assert.AreEqual(roles, APIRoles.Tier2);
+        }
+    }
+}

--- a/JilTests/JilTests.csproj
+++ b/JilTests/JilTests.csproj
@@ -106,6 +106,7 @@
     <Compile Include="DeserializeDynamicTests.cs" />
     <Compile Include="DeserializeTests.cs" />
     <Compile Include="DynamicSerializationTests.cs" />
+    <Compile Include="EnumFlagsTest.cs" />
     <Compile Include="ExhaustiveTests.cs" />
     <Compile Include="BadlySpecifiedTypeTests.cs" />
     <Compile Include="SerializeTests.cs" />


### PR DESCRIPTION
Fixed InvalidCastException issue with deserializing certain Flags Enums.  A constant value 0 is passed into EnumLookup.LoadConstantOfType in a few spots as an integer when the underlying type could be any underlying Enum type.  When different InvalidCastException occurs.  

Fix is to pass the 0 in as the correct underlying type.

Added a couple unit tests showing the issue and verifying the fix.