### PR TITLE
Support Deserialization of ISet

### DIFF
--- a/Jil/Common/ExtensionMethods.cs
+++ b/Jil/Common/ExtensionMethods.cs
@@ -709,6 +709,11 @@ namespace Jil.Common
             return t.GetContainerInterface(typeof(IList<>));
         }
 
+        public static Type GetSetInterface(this Type t)
+        {
+            return t.GetContainerInterface(typeof(ISet<>));
+        }
+
         public static Type GetReadOnlyListInterface(this Type t)
         {
             return t.GetContainerInterface(typeof(IReadOnlyList<>));
@@ -732,6 +737,11 @@ namespace Jil.Common
         public static bool IsDictionaryType(this Type t)
         {
             return t.IsContainerType(typeof(IDictionary<,>));
+        }
+
+        public static bool IsSetType(this Type t)
+        {
+            return t.IsContainerType(typeof(ISet<>));
         }
 
         public static Type GetContainerInterface(this Type t, Type containerType)

--- a/Jil/Deserialize/InlineDeserializer.cs
+++ b/Jil/Deserialize/InlineDeserializer.cs
@@ -1216,8 +1216,7 @@ namespace Jil.Deserialize
                 Emit.BranchIfEqual(done);                       // listType(*?)
                 Build(listMember, elementType);                             // listType(*?) elementType
                 Emit.CallVirtual(addMtd);                       // --empty--
-                if (isSet)
-                    Emit.Pop(); // if it's a set, Add returns a bool
+                if (isSet) Emit.Pop();                          // if it's a set, Add() returns a bool which we need to pop off the stack
 
                 var startLoop = Emit.DefineLabel();
                 var nextItem = Emit.DefineLabel();
@@ -1241,8 +1240,7 @@ namespace Jil.Deserialize
                 ConsumeWhiteSpace();                // listType(*?)
                 Build(listMember, elementType);                 // listType(*?) elementType
                 Emit.CallVirtual(addMtd);           // --empty--
-                if (isSet)
-                    Emit.Pop(); // if it's a set, Add returns a bool
+                if (isSet) Emit.Pop();              // if it's a set, Add() returns a bool which we need to pop off the stack
                 Emit.Branch(startLoop);             // --empty--
 
                 Emit.MarkLabel(done);               // listType(*?)

--- a/JilTests/DeserializeTests.cs
+++ b/JilTests/DeserializeTests.cs
@@ -811,6 +811,44 @@ namespace JilTests
         }
 
 #pragma warning disable 0649
+        class _ISets
+        {
+            public ISet<int> IntSet;
+            public HashSet<string> StringHashSet;
+            public SortedSet<int> IntSortedSet;
+        }
+#pragma warning restore 0649
+
+        [TestMethod]
+        public void ISets()
+        {
+            using (var str = new StringReader("{\"IntSet\":[17,23],\"StringHashSet\":[\"Hello\",\"Hash\",\"Set\"],\"IntSortedSet\":[1,2,3]}"))
+            {
+                var res = JSON.Deserialize<_ISets>(str);
+                Assert.IsNotNull(res);
+
+
+                Assert.IsNotNull(res.IntSet);
+                Assert.IsInstanceOfType(res.IntSet, typeof(HashSet<int>));
+                Assert.AreEqual(2, res.IntSet.Count);
+                Assert.IsTrue(res.IntSet.Contains(17));
+                Assert.IsTrue(res.IntSet.Contains(23));
+
+                Assert.IsNotNull(res.StringHashSet);
+                Assert.AreEqual(3, res.StringHashSet.Count);
+                Assert.IsTrue(res.StringHashSet.Contains("Hello"));
+                Assert.IsTrue(res.StringHashSet.Contains("Hash"));
+                Assert.IsTrue(res.StringHashSet.Contains("Set"));
+
+                Assert.IsNotNull(res.IntSortedSet);
+                Assert.AreEqual(3, res.IntSortedSet.Count);
+                Assert.IsTrue(res.IntSortedSet.Contains(1));
+                Assert.IsTrue(res.IntSortedSet.Contains(2));
+                Assert.IsTrue(res.IntSortedSet.Contains(3));
+            }
+        }
+
+#pragma warning disable 0649
         class _InfoFailure
         {
             public decimal? questions_per_minute;


### PR DESCRIPTION
It was brought up in #105 that Jil does not support deserializing sets (ISet, HashSet, SortedSet), and the rationale given was that JSON doesn't have any explicit representation of a set, and therefore Jil shouldn't support it.

I believe that the reasons for declining that feature are a bit faulty for a few reasons:

1. Jil supports _serializing_ sets, so there's a lack of symmetry.
2. Although a _debug_ build of Jil throws an exception when you try to deserialize a HashSet, a _release_ build of Jil (including what's distributed via nuget) does something far more appalling... it actually assigns a `List<>` object to the `HashSet<>` property, and then when you try to access members of the HashSet, the CLR itself crashes with a FatalExecutionEngineError.
3. It's true that JSON doesn't have explicit sets, but, by that logic, Jil shouldn't support dates either (yes, I know that would have actually made life _a lot_ easier for you, so maybe a bad example). The point is, there is utility in supporting it, even if the mapping isn't _exact_.
4. A JSON array is very reasonable choice for representing a set. The fact that `HashSet<T>` implements `IEnumerable<T>` and also accepts an `IEnumerable<T>` as a constructor argument for populating the hash speaks strongly in favor of a JSON array being a good option.
5. There was some discussion about "what if the elements of the array you're deserializing are not unique? What should the behavior be then?" I would argue that the correct convention has already been settled by the behavior of the HashSet constructor which takes an IEnumerable - it simply calls `Add()` for each item, and `Add()` can be called multiple times with the same value without it blowing up.

Even though sets are certainly less common than dates, I think there is real utility in supporting them. This also wasn't a random pull request, we have some data models in Calculon which serialize and deserialize sets, and we have to build workarounds for them. It would be nice if we didn't.

So, with all of those things in mind, I've written the support for deserializing `ISet<T>`, and added tests for them. As I said, serialization support already existed.

Any thoughts?