### PR TITLE
Fix issue 258

### DIFF
--- a/JilTests/SerializeTests.cs
+++ b/JilTests/SerializeTests.cs
@@ -9622,5 +9622,27 @@ namespace JilTests
                 Assert.AreEqual("{\"Foo\":\"Bar\"}", json);
             }
         }
+        
+
+        struct _Issue258
+        {
+            public string[] Elements { get; }
+            public _Issue258(string[] elements)
+            {
+                Elements = elements;
+            }
+        }
+        [TestMethod]
+        public void Issue258()
+        {
+            {
+                var json = JSON.Serialize(new _Issue258(new[] { "foo" }));
+                Assert.AreEqual("{\"Elements\":[\"foo\"]}", json);
+            }
+            {
+                var json = JSON.Serialize(new _Issue258(null));
+                Assert.AreEqual("{\"Elements\":null}", json);
+            }
+        }
     }
 }


### PR DESCRIPTION
The `get` method of a property in a struct expects a pointer to the struct, not the struct itself, as the `this` argument. The logic was correct further down in the method, but not in the branch where the property was an IList or an IDictionary. This fixes #258 