### PR TITLE
Allow field layout to be determined for more types

### DIFF
--- a/Jil/Common/Utils.cs
+++ b/Jil/Common/Utils.cs
@@ -474,6 +474,11 @@ namespace Jil.Common
 
                 var getAddrs = emit.CreateDelegate(Utils.DelegateOptimizationOptions);
 
+#if NETCORE
+                // When FormatterServices isn't available on the target platform,
+                // create an object of the type by invoking one of it's constructors
+                // with default values for each of the parameters.
+                // NOTE: FormatterServices is available on .NET Framework 1.1+ and netstandard2.0.
                 var cons = t.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).OrderBy(p => p.GetParameters().Count()).FirstOrDefault();
                 var consParameters = cons != null ? cons.GetParameters().Select(p => p.ParameterType.DefaultValue()).ToArray() : null;
 
@@ -486,6 +491,13 @@ namespace Jil.Common
                 {
                     obj = Activator.CreateInstance(t);
                 }
+#else
+                // Get an uninitialized object of the specified type.
+                // This is preferable to invoking a constructor of the type -- this method does not
+                // invoke any constructor for the type, so allows the field layout to be determined
+                // even when a type has constructors which e.g. check-then-throw for null arguments.
+                object obj = FormatterServices.GetUninitializedObject(t);
+#endif
 
                 var addrs = getAddrs(obj);
 


### PR DESCRIPTION
Use the ``FormatterServices.GetUninitializedObject()`` method to get an instance of a specified type without having to invoke one of the ctors for the type; this allows the field layout to be determined for a wider set of types, e.g., types whose ctors check-then-throw for null arguments. An additional benefit of this change is that because the ctors for those types are no longer run, they no longer raise exceptions which cause the VS debugger to break (pause execution).

I built/ran the full test suite after making the change, and all of the tests passed except for one (an ISO8601-related test for ``TimeSpan``) which doesn't seem related.