### PR TITLE
RawJson implementation (partial parsing)

### DIFF
--- a/Jil.sln
+++ b/Jil.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26403.7
+VisualStudioVersion = 15.0.26730.10
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C918E754-B4AA-43CC-81DE-CC0D0B806A59}"
 	ProjectSection(SolutionItems) = preProject
@@ -62,18 +62,21 @@ Global
 		{0EDD50BE-0CCD-48E1-A613-4A623F543492}.Release|Any CPU.Build.0 = Release|Any CPU
 		{03029B62-21DB-4CE4-9FAB-41D3A1615EE8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{03029B62-21DB-4CE4-9FAB-41D3A1615EE8}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{03029B62-21DB-4CE4-9FAB-41D3A1615EE8}.Release_ExhaustiveTest|Any CPU.ActiveCfg = Release_ExhaustiveTest|Any CPU
-		{03029B62-21DB-4CE4-9FAB-41D3A1615EE8}.Release_ExhaustiveTest|Any CPU.Build.0 = Release_ExhaustiveTest|Any CPU
+		{03029B62-21DB-4CE4-9FAB-41D3A1615EE8}.Release_ExhaustiveTest|Any CPU.ActiveCfg = Release|Any CPU
+		{03029B62-21DB-4CE4-9FAB-41D3A1615EE8}.Release_ExhaustiveTest|Any CPU.Build.0 = Release|Any CPU
 		{03029B62-21DB-4CE4-9FAB-41D3A1615EE8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{03029B62-21DB-4CE4-9FAB-41D3A1615EE8}.Release|Any CPU.Build.0 = Release|Any CPU
 		{5F76B615-53A4-4DE0-8131-2F4BC49929EF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5F76B615-53A4-4DE0-8131-2F4BC49929EF}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5F76B615-53A4-4DE0-8131-2F4BC49929EF}.Release_ExhaustiveTest|Any CPU.ActiveCfg = Release_ExhaustiveTest|Any CPU
-		{5F76B615-53A4-4DE0-8131-2F4BC49929EF}.Release_ExhaustiveTest|Any CPU.Build.0 = Release_ExhaustiveTest|Any CPU
+		{5F76B615-53A4-4DE0-8131-2F4BC49929EF}.Release_ExhaustiveTest|Any CPU.ActiveCfg = Release|Any CPU
+		{5F76B615-53A4-4DE0-8131-2F4BC49929EF}.Release_ExhaustiveTest|Any CPU.Build.0 = Release|Any CPU
 		{5F76B615-53A4-4DE0-8131-2F4BC49929EF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5F76B615-53A4-4DE0-8131-2F4BC49929EF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {2C876A81-42AD-4EF9-8CEB-9C0AD977B49C}
 	EndGlobalSection
 EndGlobal

--- a/Jil/Common/PeekSupportingTextReader.cs
+++ b/Jil/Common/PeekSupportingTextReader.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.IO;
 
 namespace Jil.Common
 {
@@ -18,6 +13,13 @@ namespace Jil.Common
             Inner = inner;
         }
 
+        /// <summary>
+        /// Reads the next character without changing the state of the reader or the character source. Returns the next available character without actually reading it from the reader.
+        /// </summary>
+        /// <returns>
+        /// An integer representing the next character to be read, or -1 if no more characters are available or the reader does not support seeking.
+        /// </returns>
+        /// <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.IO.TextReader"/> is closed. </exception><exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
         public override int Peek()
         {
             if (Peeked != null) return Peeked.Value;
@@ -27,6 +29,13 @@ namespace Jil.Common
             return Peeked.Value;
         }
 
+        /// <summary>
+        /// Reads the next character from the text reader and advances the character position by one character.
+        /// </summary>
+        /// <returns>
+        /// The next character from the text reader, or -1 if no more characters are available. The default implementation returns -1.
+        /// </returns>
+        /// <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.IO.TextReader"/> is closed. </exception><exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
         public override int Read()
         {
             if (Peeked != null)

--- a/Jil/Deserialize/BufferedTextReaderWrapper.cs
+++ b/Jil/Deserialize/BufferedTextReaderWrapper.cs
@@ -1,0 +1,80 @@
+using System.IO;
+using System.Text;
+
+namespace Jil.Deserialize
+{
+    /// <summary>
+    /// Wraps TextReader instance 
+    /// </summary>
+    public class BufferedTextReaderWrapper : TextReader
+    {
+        private readonly TextReader _inner;
+        private readonly StringBuilder _commonStringBuilder;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="inner"></param>
+        /// <param name="commonStringBuilder"></param>
+        public BufferedTextReaderWrapper(TextReader inner, StringBuilder commonStringBuilder)
+        {
+            _inner = inner;
+            _commonStringBuilder = commonStringBuilder??new StringBuilder();
+        }
+
+        /// <summary>
+        /// Reads the next character without changing the state of the reader or the character source. Returns the next available character without actually reading it from the reader.
+        /// </summary>
+        /// <returns>
+        /// An integer representing the next character to be read, or -1 if no more characters are available or the reader does not support seeking.
+        /// </returns>
+        /// <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.IO.TextReader"/> is closed. </exception><exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
+        public override int Peek()
+        {
+            return _inner.Peek();            
+        }
+
+        /// <summary>
+        /// Reads the next character from the text reader and advances the character position by one character.
+        /// </summary>
+        /// <returns>
+        /// The next character from the text reader, or -1 if no more characters are available. The default implementation returns -1.
+        /// </returns>
+        /// <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.IO.TextReader"/> is closed. </exception><exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
+        public override int Read()
+        {
+            var res = _inner.Read();
+            if (res != -1)
+            {
+                _commonStringBuilder.Append((char) res);
+            }
+            return res;
+        }
+
+        /// <summary>
+        /// Gets buffered string
+        /// </summary>
+        /// <returns></returns>
+        public string GetBufferedString()
+        {
+            return _commonStringBuilder.ToString();
+        }
+
+        /// <summary>
+        /// Get inner reader
+        /// </summary>
+        /// <returns></returns>
+        public TextReader Unwrap => _inner;
+
+        /// <summary>
+        /// Wraps TextReader instance
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <param name="sb"></param>
+        /// <returns></returns>
+        public static BufferedTextReaderWrapper Wrap(TextReader reader, StringBuilder sb)
+        {
+            return new BufferedTextReaderWrapper(reader, sb);
+        }
+    }
+}

--- a/Jil/Deserialize/EnumLookup.cs
+++ b/Jil/Deserialize/EnumLookup.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Jil.Deserialize

--- a/Jil/Deserialize/ThunkReader.cs
+++ b/Jil/Deserialize/ThunkReader.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Jil.Deserialize
+﻿namespace Jil.Deserialize
 {
     delegate T StringThunkDelegate<T>(ref ThunkReader writer, int depth);
 
@@ -14,7 +8,7 @@ namespace Jil.Deserialize
         int Index;
 
         public int Position { get { return Index + 1; } }
-
+        
         public ThunkReader(string val) : this()
         {
             Value = val;

--- a/Jil/Jil.csproj
+++ b/Jil/Jil.csproj
@@ -101,6 +101,7 @@
     <Compile Include="DeserializeDynamic\ObjectBuilder.cs" />
     <Compile Include="Deserialize\AnonymousTypeLookup.cs" />
     <Compile Include="Common\EnumValues.cs" />
+    <Compile Include="Deserialize\BufferedTextReaderWrapper.cs" />
     <Compile Include="Deserialize\DeserializeIndirect.cs" />
     <Compile Include="Deserialize\EnumLookup.cs" />
     <Compile Include="Common\FlagsEnumCombiner.cs" />
@@ -130,6 +131,7 @@
     <Compile Include="Common\ExtensionMethods.cs" />
     <Compile Include="Deserialize\UnionLookup.cs" />
     <Compile Include="InfiniteRecursionException.cs" />
+    <Compile Include="JilClassDirectiveAttribute.cs" />
     <Compile Include="JilDirectiveAttribute.cs" />
     <Compile Include="JSON.cs" />
     <Compile Include="Options.cs" />

--- a/Jil/JilClassDirectiveAttribute.cs
+++ b/Jil/JilClassDirectiveAttribute.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+namespace Jil
+{
+    /// <summary>
+    /// When applied to a class allows configuration
+    /// of the name of the property to store raw json string
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public class JilClassDirectiveAttribute : Attribute
+    {
+        /// <summary>
+        /// Name of the property to store raw json string
+        /// </summary>
+        public string RawPropertyName { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public JilClassDirectiveAttribute()
+        {
+            
+        }
+        /// <summary>
+        /// Create a new JilClassDirectiveAttribute
+        /// </summary>
+        /// <param name="rawPropertyName">Name of the property to store raw json string</param>
+        public JilClassDirectiveAttribute(string rawPropertyName)
+        {
+            RawPropertyName = rawPropertyName;
+        }
+    }
+}

--- a/JilTests/JilTests.csproj
+++ b/JilTests/JilTests.csproj
@@ -111,6 +111,7 @@
     <Compile Include="ExhaustiveTests.cs" />
     <Compile Include="BadlySpecifiedTypeTests.cs" />
     <Compile Include="ExtensionMethods.cs" />
+    <Compile Include="RawPropertyNameTest.cs" />
     <Compile Include="SerializeTests.cs" />
     <Compile Include="SpeedProofTests.cs" />
     <Compile Include="UtilsTests.cs" />

--- a/JilTests/RawPropertyNameTest.cs
+++ b/JilTests/RawPropertyNameTest.cs
@@ -1,0 +1,52 @@
+using System.IO;
+using Jil;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace JilTests
+{
+    [TestClass]
+    public class RawPropertyNameTest
+    {
+        [TestMethod]
+        public void RawPropertyFromString()
+        {
+            var item1Json = "{\"id\":\"1\", \"additional\":90}";
+            var item2Json = "{\"id\":\"2\"}";
+            var dataToParse = $"{{\"data\":[{item1Json}, {item2Json}]}}";
+            var parsed = JSON.Deserialize<Items>(dataToParse);
+            Assert.AreEqual(item1Json,parsed.Data[0].Raw);
+            Assert.AreEqual(item2Json,parsed.Data[1].Raw);
+            Assert.AreEqual("1",parsed.Data[0].Id);
+            Assert.AreEqual("2",parsed.Data[1].Id);
+        }
+
+        [TestMethod]
+        public void RawPropertyFromStream()
+        {
+            var item1Json = "{\"id\":\"1\", \"additional\":90}";
+            var item2Json = "{\"id\":\"2\"}";
+            var dataToParse =new StringReader( $"{{\"data\":[{item1Json}, {item2Json}]}}");
+            
+            var parsed = JSON.Deserialize<Items>(dataToParse);
+            Assert.AreEqual(item1Json,parsed.Data[0].Raw);
+            Assert.AreEqual(item2Json,parsed.Data[1].Raw);
+            Assert.AreEqual("1",parsed.Data[0].Id);
+            Assert.AreEqual("2",parsed.Data[1].Id);
+        }
+
+        public class Items
+        {
+            [JilDirective(Name = "data")]
+            public Item[] Data { get; set; }
+        }
+
+        [JilClassDirective("Raw")]
+        public class Item
+        {
+            [JilDirective(Name = "id")]
+            public string Id { get; set; }
+            [JilDirective(Ignore = true)]
+            public string Raw { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Our team is developing a service wich receives lots of json documents. The documents are relatively big and we don't want to parse them fully. So we implemented it as an attribute which applies to the mapping class and allows to specify the name of the property where to keep all the 'raw json' without parsing

For example:

{
  documents:[
    {
      AnchorToDocumentDetails: "http://nextdocument.xxx/...."  /// Required during the crawling process
      SomeField1:"..loooong string..",
      SomeField2:"....",
      SomeFieldX:"....",
      ....
    },    
    ......
  ]
}

Pseudo code:

[JilClassDirectiveAttribute(RawPropertyName="Raw"]
class Document
{
  public string AnchorToDocumentDetails;
  public string Raw;
}

var docs = Service.GetDocuments()
var detailsList = docs.Select(d => Service.GetDetails(d.AnchorToDocumentDetails)

docs.Foreach(d =>File.Save(d)) // Should be saved with all other fields
detailsList.Foreach(details =>File.Save(details))
