### PR TITLE
Issue #320 : Fix precision in serialization of double and float

### DIFF
--- a/Jil/Serialize/Methods.cs
+++ b/Jil/Serialize/Methods.cs
@@ -1263,7 +1263,7 @@ namespace Jil.Serialize
                 return;
             }
 
-            writer.Write(f.ToString(invariant));
+            writer.Write(f.ToString("R",invariant));
         }
 
         static readonly MethodInfo ProxyDouble = typeof(Methods).GetMethod("_ProxyDouble", BindingFlags.Static | BindingFlags.NonPublic);
@@ -1279,7 +1279,7 @@ namespace Jil.Serialize
                 return;
             }
 
-            writer.Write(d.ToString(invariant));
+            writer.Write(d.ToString("R",invariant));
         }
 
         static readonly MethodInfo ProxyDecimal = typeof(Methods).GetMethod("_ProxyDecimal", BindingFlags.Static | BindingFlags.NonPublic);

--- a/Jil/Serialize/ThunkWriter.cs
+++ b/Jil/Serialize/ThunkWriter.cs
@@ -287,13 +287,13 @@ namespace Jil.Serialize
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Write(float f)
         {
-            Write(f.ToString(CultureInfo.InvariantCulture));
+            Write(f.ToString("R",CultureInfo.InvariantCulture));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Write(double d)
         {
-            Write(d.ToString(CultureInfo.InvariantCulture));
+            Write(d.ToString("R",CultureInfo.InvariantCulture));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/JilTests/DynamicSerializationTests.cs
+++ b/JilTests/DynamicSerializationTests.cs
@@ -968,7 +968,7 @@ namespace JilTests
                     stringJson = JSON.SerializeDynamic(ts, Options.SecondsSinceUnixEpoch);
                 }
 
-                var dotNetStr = ts.TotalSeconds.ToString(CultureInfo.InvariantCulture);
+                var dotNetStr = ts.TotalSeconds.ToString("R",CultureInfo.InvariantCulture);
 
                 if (dotNetStr.IndexOf('.') != -1) dotNetStr = dotNetStr.TrimEnd('0');
                 if (streamJson.IndexOf('.') != -1) streamJson = streamJson.TrimEnd('0');
@@ -1019,7 +1019,7 @@ namespace JilTests
                     stringJson = JSON.SerializeDynamic(ts, Options.MillisecondsSinceUnixEpoch);
                 }
 
-                var dotNetStr = ts.TotalMilliseconds.ToString();
+                var dotNetStr = ts.TotalMilliseconds.ToString("R", CultureInfo.InvariantCulture);
 
                 if (dotNetStr.IndexOf('.') != -1) dotNetStr = dotNetStr.TrimEnd('0');
                 if (streamJson.IndexOf('.') != -1) streamJson = streamJson.TrimEnd('0');
@@ -1394,7 +1394,7 @@ namespace JilTests
                 const string json = "4.3563456344358765e+10";
 
                 double res = JSON.DeserializeDynamic(json);
-                var shouldMatch = double.Parse(json);
+                var shouldMatch = double.Parse(json,NumberStyles.AllowDecimalPoint | NumberStyles.AllowExponent, CultureInfo.InvariantCulture);
                 var diff = Math.Abs(res - shouldMatch);
 
                 Assert.Equal(shouldMatch, res);
@@ -1404,7 +1404,7 @@ namespace JilTests
                 const string json = "4.356345634435876535634563443587653563456344358765356345634435876535634563443587653563456344358765e+10";
 
                 double res = JSON.DeserializeDynamic(json);
-                var shouldMatch = double.Parse(json);
+                var shouldMatch = double.Parse(json, NumberStyles.AllowDecimalPoint | NumberStyles.AllowExponent, CultureInfo.InvariantCulture);
                 var diff = Math.Abs(res - shouldMatch);
 
                 Assert.Equal(shouldMatch, res);
@@ -1414,7 +1414,7 @@ namespace JilTests
                 const string json = "4.444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444445e+10";
 
                 double res = JSON.DeserializeDynamic(json);
-                var shouldMatch = double.Parse(json);
+                var shouldMatch = double.Parse(json, NumberStyles.AllowDecimalPoint | NumberStyles.AllowExponent, CultureInfo.InvariantCulture);
                 var diff = Math.Abs(res - shouldMatch);
 
                 Assert.Equal(shouldMatch, res);

--- a/JilTests/SerializeTests.cs
+++ b/JilTests/SerializeTests.cs
@@ -6638,6 +6638,28 @@ namespace JilTests
                 }
             }
         }
+
+        class _DoubleMinWeirdCulture
+        {
+            public double Const { get { return Double.MinValue; } }
+        }
+        [Fact]
+        public void DoubleMinWeirdCulture()
+        {
+            var allCultures = CultureInfo.GetCultures(CultureTypes.AllCultures);
+            var currentCulture = CultureInfo.CurrentCulture;
+            var weirdCulture = allCultures.Where(c => c.NumberFormat.CurrencyDecimalSeparator != "." && c != currentCulture).First();
+
+            using (new _DoubleWeirdCulture(weirdCulture))
+            {
+                using (var str = new StringWriter())
+                {
+                    JSON.Serialize(new _DoubleMinWeirdCulture(), str);
+                    var res = str.ToString();
+                    Assert.Equal("{\"Const\":-1.7976931348623157E+308}", res);
+                }
+            }
+        }
 #endif
 
         class _Enumerables
@@ -7552,7 +7574,7 @@ namespace JilTests
                     stringJson = JSON.Serialize(ts, Options.SecondsSinceUnixEpoch);
                 }
 
-                var dotNetStr = ts.TotalSeconds.ToString(CultureInfo.InvariantCulture);
+                var dotNetStr = ts.TotalSeconds.ToString("R",CultureInfo.InvariantCulture);
 
                 if (dotNetStr.IndexOf('.') != -1) dotNetStr = dotNetStr.TrimEnd('0');
                 if (streamJson.IndexOf('.') != -1) streamJson = streamJson.TrimEnd('0');
@@ -7603,7 +7625,7 @@ namespace JilTests
                     stringJson = JSON.Serialize(ts, Options.MillisecondsSinceUnixEpoch);
                 }
 
-                var dotNetStr = ts.TotalMilliseconds.ToString();
+                var dotNetStr = ts.TotalMilliseconds.ToString("R",CultureInfo.InvariantCulture);
 
                 if (dotNetStr.IndexOf('.') != -1) dotNetStr = dotNetStr.TrimEnd('0');
                 if (streamJson.IndexOf('.') != -1) streamJson = streamJson.TrimEnd('0');


### PR DESCRIPTION
See #320 , I got a crash when serializing and then deserializing double.MinValue / double.MaxValue.
Using ToString("R" ... fixed this issue.

Inpiring by Newtonsoft.JSON way to serializing float/double